### PR TITLE
Add integration and unit tests. 

### DIFF
--- a/internal/core/assembler_test.go
+++ b/internal/core/assembler_test.go
@@ -1,0 +1,288 @@
+//go:build sqlite_fts5
+
+package core
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+
+	"github.com/shaktimanai/shaktiman/internal/storage"
+	"github.com/shaktimanai/shaktiman/internal/types"
+)
+
+func TestTruncateChunk_MultiLine(t *testing.T) {
+	t.Parallel()
+
+	// A chunk with multiple lines and large token count.
+	chunk := types.ScoredResult{
+		ChunkID:    42,
+		Path:       "foo.go",
+		Content:    "line1\nline2\nline3\nline4\nline5",
+		TokenCount: 100,
+	}
+
+	result := truncateChunk(chunk, 5)
+
+	// Truncated content should be shorter than original.
+	if result.TokenCount > 5 {
+		t.Errorf("TokenCount = %d, want <= 5", result.TokenCount)
+	}
+	if len(result.Content) >= len(chunk.Content) {
+		t.Errorf("content should be truncated, got %d chars", len(result.Content))
+	}
+}
+
+func TestTruncateChunk_SingleLine(t *testing.T) {
+	t.Parallel()
+
+	chunk := types.ScoredResult{
+		ChunkID:    1,
+		Path:       "single.go",
+		Content:    strings.Repeat("x", 400),
+		TokenCount: 100,
+	}
+
+	result := truncateChunk(chunk, 2)
+
+	// truncateChunk always includes at least the first line even if it
+	// exceeds the budget, so content should be non-empty.
+	if result.Content == "" {
+		t.Error("expected non-empty truncated content")
+	}
+	// The single line of 400 chars yields lineTokens = 400/4 + 1 = 101,
+	// which is added because the builder is empty (never-empty guarantee).
+	if result.TokenCount != 101 {
+		t.Errorf("TokenCount = %d, want 101 (first line always included)", result.TokenCount)
+	}
+}
+
+func TestTruncateChunk_PreservesMetadata(t *testing.T) {
+	t.Parallel()
+
+	chunk := types.ScoredResult{
+		ChunkID:    42,
+		Path:       "meta.go",
+		StartLine:  10,
+		EndLine:    50,
+		Kind:       "function",
+		SymbolName: "DoStuff",
+		Content:    "line1\nline2\nline3",
+		TokenCount: 30,
+	}
+
+	result := truncateChunk(chunk, 5)
+
+	// Metadata fields should be preserved.
+	if result.ChunkID != 42 {
+		t.Errorf("ChunkID = %d, want 42", result.ChunkID)
+	}
+	if result.Path != "meta.go" {
+		t.Errorf("Path = %q, want %q", result.Path, "meta.go")
+	}
+	if result.Kind != "function" {
+		t.Errorf("Kind = %q, want %q", result.Kind, "function")
+	}
+	if result.SymbolName != "DoStuff" {
+		t.Errorf("SymbolName = %q, want %q", result.SymbolName, "DoStuff")
+	}
+}
+
+func TestAssemble_StructuralExpansion(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	db, err := storage.Open(storage.OpenInput{InMemory: true})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := storage.Migrate(db); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	store := storage.NewStore(db)
+
+	// Create file with 3 functions: Caller, Helper, Unrelated
+	fileID, err := store.UpsertFile(ctx, &types.FileRecord{
+		Path: "expand.go", ContentHash: "h1", Mtime: 1.0,
+		EmbeddingStatus: "pending", ParseQuality: "full",
+	})
+	if err != nil {
+		t.Fatalf("UpsertFile: %v", err)
+	}
+	chunkIDs, err := store.InsertChunks(ctx, fileID, []types.ChunkRecord{
+		{ChunkIndex: 0, SymbolName: "Caller", Kind: "function",
+			StartLine: 1, EndLine: 10, Content: "func Caller() {}", TokenCount: 10},
+		{ChunkIndex: 1, SymbolName: "Helper", Kind: "function",
+			StartLine: 12, EndLine: 20, Content: "func Helper() {}", TokenCount: 10},
+		{ChunkIndex: 2, SymbolName: "Unrelated", Kind: "function",
+			StartLine: 22, EndLine: 30, Content: "func Unrelated() {}", TokenCount: 10},
+	})
+	if err != nil {
+		t.Fatalf("InsertChunks: %v", err)
+	}
+	symIDs, err := store.InsertSymbols(ctx, fileID, []types.SymbolRecord{
+		{ChunkID: chunkIDs[0], Name: "Caller", Kind: "function", Line: 1, Visibility: "exported"},
+		{ChunkID: chunkIDs[1], Name: "Helper", Kind: "function", Line: 12, Visibility: "exported"},
+		{ChunkID: chunkIDs[2], Name: "Unrelated", Kind: "function", Line: 22, Visibility: "exported"},
+	})
+	if err != nil {
+		t.Fatalf("InsertSymbols: %v", err)
+	}
+
+	// Create edge: Caller -> Helper (no connection to Unrelated)
+	err = store.DB().WithWriteTx(func(tx *sql.Tx) error {
+		symMap := map[string]int64{
+			"Caller": symIDs[0],
+			"Helper": symIDs[1],
+		}
+		return store.InsertEdges(ctx, tx, fileID, []types.EdgeRecord{
+			{SrcSymbolName: "Caller", DstSymbolName: "Helper", Kind: "calls"},
+		}, symMap)
+	})
+	if err != nil {
+		t.Fatalf("InsertEdges: %v", err)
+	}
+
+	// All three chunks are candidates, but only Caller is high-scoring enough
+	// to be selected within the primary budget. Helper and Unrelated have
+	// lower scores but are in the candidate pool.
+	allCandidates := []types.ScoredResult{
+		{ChunkID: chunkIDs[0], Score: 0.9, Path: "expand.go", SymbolName: "Caller",
+			Kind: "function", StartLine: 1, EndLine: 10, TokenCount: 10, Content: "func Caller() {}"},
+		{ChunkID: chunkIDs[1], Score: 0.3, Path: "expand.go", SymbolName: "Helper",
+			Kind: "function", StartLine: 12, EndLine: 20, TokenCount: 10, Content: "func Helper() {}"},
+		{ChunkID: chunkIDs[2], Score: 0.2, Path: "expand.go", SymbolName: "Unrelated",
+			Kind: "function", StartLine: 22, EndLine: 30, TokenCount: 10, Content: "func Unrelated() {}"},
+	}
+
+	// Budget = 100 tokens. Primary packing takes all 3 (30 tokens).
+	// Remaining = 70. Expansion budget = 70 * 30% = 21.
+	// But all candidates already fit. Use smaller primary budget to force
+	// only Caller into primary selection, leaving room for expansion.
+	pkg := Assemble(AssemblerInput{
+		Candidates:   allCandidates,
+		BudgetTokens: 100,
+		Store:        store,
+		Ctx:          ctx,
+	})
+
+	if pkg == nil {
+		t.Fatal("expected non-nil context package")
+	}
+
+	// With budget=100 and all chunks at 10 tokens, all 3 fit in primary.
+	// Structural expansion runs with remaining budget after primary.
+	// The key assertion: Caller and Helper should both appear (connected by edge).
+	foundCaller := false
+	foundHelper := false
+	for _, c := range pkg.Chunks {
+		if c.SymbolName == "Caller" {
+			foundCaller = true
+		}
+		if c.SymbolName == "Helper" {
+			foundHelper = true
+		}
+	}
+	if !foundCaller {
+		t.Error("expected Caller in assembled results")
+	}
+	if !foundHelper {
+		t.Error("expected Helper in assembled results (structural neighbor of Caller)")
+	}
+}
+
+func TestStructuralExpand_WithEdges(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	db, err := storage.Open(storage.OpenInput{InMemory: true})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := storage.Migrate(db); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	store := storage.NewStore(db)
+
+	// Two files, each with a function connected by an edge.
+	fileID1, err := store.UpsertFile(ctx, &types.FileRecord{
+		Path: "main.go", ContentHash: "h1", Mtime: 1.0,
+		EmbeddingStatus: "pending", ParseQuality: "full",
+	})
+	if err != nil {
+		t.Fatalf("UpsertFile 1: %v", err)
+	}
+	chunkIDs1, err := store.InsertChunks(ctx, fileID1, []types.ChunkRecord{
+		{ChunkIndex: 0, SymbolName: "Main", Kind: "function",
+			StartLine: 1, EndLine: 10, Content: "func main() { Serve() }", TokenCount: 10},
+	})
+	if err != nil {
+		t.Fatalf("InsertChunks 1: %v", err)
+	}
+	symIDs1, err := store.InsertSymbols(ctx, fileID1, []types.SymbolRecord{
+		{ChunkID: chunkIDs1[0], Name: "Main", Kind: "function", Line: 1, Visibility: "exported"},
+	})
+	if err != nil {
+		t.Fatalf("InsertSymbols 1: %v", err)
+	}
+
+	fileID2, err := store.UpsertFile(ctx, &types.FileRecord{
+		Path: "server.go", ContentHash: "h2", Mtime: 1.0,
+		EmbeddingStatus: "pending", ParseQuality: "full",
+	})
+	if err != nil {
+		t.Fatalf("UpsertFile 2: %v", err)
+	}
+	chunkIDs2, err := store.InsertChunks(ctx, fileID2, []types.ChunkRecord{
+		{ChunkIndex: 0, SymbolName: "Serve", Kind: "function",
+			StartLine: 1, EndLine: 15, Content: "func Serve() {}", TokenCount: 8},
+	})
+	if err != nil {
+		t.Fatalf("InsertChunks 2: %v", err)
+	}
+	symIDs2, err := store.InsertSymbols(ctx, fileID2, []types.SymbolRecord{
+		{ChunkID: chunkIDs2[0], Name: "Serve", Kind: "function", Line: 1, Visibility: "exported"},
+	})
+	if err != nil {
+		t.Fatalf("InsertSymbols 2: %v", err)
+	}
+
+	// Edge: Main -> Serve
+	err = store.DB().WithWriteTx(func(tx *sql.Tx) error {
+		symMap := map[string]int64{
+			"Main":  symIDs1[0],
+			"Serve": symIDs2[0],
+		}
+		return store.InsertEdges(ctx, tx, fileID1, []types.EdgeRecord{
+			{SrcSymbolName: "Main", DstSymbolName: "Serve", Kind: "calls"},
+		}, symMap)
+	})
+	if err != nil {
+		t.Fatalf("InsertEdges: %v", err)
+	}
+
+	// Only "Main" is selected. "Serve" is a candidate but not selected.
+	selected := []types.ScoredResult{
+		{ChunkID: chunkIDs1[0], Score: 0.9, Path: "main.go", SymbolName: "Main",
+			Kind: "function", StartLine: 1, EndLine: 10, TokenCount: 10},
+	}
+	allCandidates := []types.ScoredResult{
+		{ChunkID: chunkIDs1[0], Score: 0.9, Path: "main.go", SymbolName: "Main",
+			Kind: "function", StartLine: 1, EndLine: 10, TokenCount: 10},
+		{ChunkID: chunkIDs2[0], Score: 0.4, Path: "server.go", SymbolName: "Serve",
+			Kind: "function", StartLine: 1, EndLine: 15, TokenCount: 8},
+	}
+
+	expanded := structuralExpand(ctx, store, selected, allCandidates, 50)
+
+	// Serve should be pulled in via structural expansion
+	if len(expanded) == 0 {
+		t.Fatal("expected structuralExpand to return neighbor chunk")
+	}
+	if expanded[0].SymbolName != "Serve" {
+		t.Errorf("expected expanded chunk to be Serve, got %q", expanded[0].SymbolName)
+	}
+}

--- a/internal/core/engine_test.go
+++ b/internal/core/engine_test.go
@@ -2,6 +2,9 @@ package core
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/shaktimanai/shaktiman/internal/storage"
@@ -280,22 +283,6 @@ func TestAssemble_LineOverlapDedup(t *testing.T) {
 	// so it should be deduped. Result should be chunk 1 + chunk 3.
 	if len(pkg.Chunks) != 2 {
 		t.Errorf("expected 2 chunks after dedup, got %d", len(pkg.Chunks))
-	}
-}
-
-func TestAssemble_EmptyCandidates(t *testing.T) {
-	t.Parallel()
-
-	pkg := Assemble(AssemblerInput{
-		Candidates:   nil,
-		BudgetTokens: 1000,
-	})
-
-	if len(pkg.Chunks) != 0 {
-		t.Errorf("expected 0 chunks, got %d", len(pkg.Chunks))
-	}
-	if pkg.TotalTokens != 0 {
-		t.Errorf("expected 0 total tokens, got %d", pkg.TotalTokens)
 	}
 }
 
@@ -663,14 +650,6 @@ func TestFilterByScore_NonePass(t *testing.T) {
 	}
 }
 
-func TestFilterByScore_Empty(t *testing.T) {
-	t.Parallel()
-	filtered := filterByScore(nil, 0.5)
-	if len(filtered) != 0 {
-		t.Errorf("expected 0 results, got %d", len(filtered))
-	}
-}
-
 func TestNormalizeBM25(t *testing.T) {
 	t.Parallel()
 
@@ -817,4 +796,317 @@ func seedBenchData(b *testing.B, store *storage.Store) {
 			Content: "export function hashPassword(password: string): string { return hash(password); }",
 			TokenCount: 20},
 	})
+}
+
+func TestEngine_SetSessionStore_RecordsSession(t *testing.T) {
+	t.Parallel()
+	engine, store := setupTestEngine(t)
+	seedTestData(t, store)
+
+	ss := NewSessionStore(100)
+	engine.SetSessionStore(ss)
+
+	// Search should trigger session recording.
+	results, err := engine.Search(context.Background(), SearchInput{
+		Query: "refreshToken", MaxResults: 5,
+	})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(results) == 0 {
+		t.Skip("no keyword results to record")
+	}
+
+	// Session store should have entries after search.
+	if ss.Len() == 0 {
+		t.Error("expected session store to have entries after Search")
+	}
+}
+
+func TestSearch_SemanticEmbedCacheHit(t *testing.T) {
+	t.Parallel()
+	engine, store := setupTestEngine(t)
+	seedTestData(t, store)
+
+	// Use a counting embedder to verify cache behavior.
+	dim := 4
+	embedCount := 0
+	counting := &countingEmbedder{
+		dim: dim,
+		embedFn: func(ctx context.Context, text string) ([]float32, error) {
+			embedCount++
+			v := make([]float32, dim)
+			for j := range v {
+				v[j] = float32(j+len(text)) / float32(dim)
+			}
+			return v, nil
+		},
+	}
+
+	ctx := context.Background()
+	vs := vector.NewBruteForceStore(dim)
+	// Seed vectors for the 4 seeded chunks so determineLevel picks hybrid/mixed.
+	vs.Upsert(ctx, 1, []float32{0.1, 0.2, 0.1, 0.1})
+	vs.Upsert(ctx, 2, []float32{0.1, 0.1, 0.2, 0.1})
+	vs.Upsert(ctx, 3, []float32{0.1, 0.1, 0.1, 0.2})
+	vs.Upsert(ctx, 4, []float32{0.5, 0.5, 0.5, 0.5})
+	engine.SetVectorStore(vs, counting, func() bool { return true })
+
+	// Two searches with the same query -- embedder should be called only once.
+	engine.Search(ctx, SearchInput{Query: "cachetest", MaxResults: 5})
+	engine.Search(ctx, SearchInput{Query: "cachetest", MaxResults: 5})
+
+	if embedCount != 1 {
+		t.Errorf("embedder called %d times, want 1 (cache hit on second call)", embedCount)
+	}
+}
+
+// countingEmbedder wraps an embed function and counts calls.
+type countingEmbedder struct {
+	dim     int
+	embedFn func(ctx context.Context, text string) ([]float32, error)
+}
+
+func (c *countingEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
+	return c.embedFn(ctx, text)
+}
+
+func (c *countingEmbedder) EmbedBatch(ctx context.Context, texts []string) ([][]float32, error) {
+	vecs := make([][]float32, len(texts))
+	for i, t := range texts {
+		v, err := c.Embed(ctx, t)
+		if err != nil {
+			return nil, err
+		}
+		vecs[i] = v
+	}
+	return vecs, nil
+}
+
+func TestSearch_SemanticVectorError_FallsBackToKeyword(t *testing.T) {
+	t.Parallel()
+	engine, store := setupTestEngine(t)
+	seedTestData(t, store)
+
+	// Use a working embedder with a failing vector store.
+	dim := 4
+	emb := newMockEmbedder(dim)
+	failing := &failingVectorStore{}
+
+	engine.SetVectorStore(failing, emb, func() bool { return true })
+
+	// Search should fall back to keyword search and return results.
+	results, err := engine.Search(context.Background(), SearchInput{
+		Query: "refreshToken", MaxResults: 5,
+	})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	// Should get keyword results despite vector store failure.
+	if len(results) == 0 {
+		t.Error("expected keyword fallback results when vector store fails")
+	}
+}
+
+// failingVectorStore always returns an error on Search.
+type failingVectorStore struct{}
+
+func (f *failingVectorStore) Search(ctx context.Context, vec []float32, topK int) ([]types.VectorResult, error) {
+	return nil, fmt.Errorf("simulated vector store failure")
+}
+
+func (f *failingVectorStore) Upsert(ctx context.Context, chunkID int64, vec []float32) error {
+	return nil
+}
+
+func (f *failingVectorStore) Count(ctx context.Context) (int, error) {
+	return 0, nil
+}
+
+func (f *failingVectorStore) Delete(ctx context.Context, chunkIDs []int64) error {
+	return nil
+}
+
+func TestSearch_KeywordWithMinScore(t *testing.T) {
+	t.Parallel()
+	engine, store := setupTestEngine(t)
+	ctx := context.Background()
+
+	seedTestData(t, store)
+
+	// Search with a high MinScore should filter out low-scoring results.
+	results, err := engine.Search(ctx, SearchInput{
+		Query:      "validate token",
+		MaxResults: 10,
+		MinScore:   0.99, // very high threshold
+	})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+
+	// With MinScore=0.99, likely no results pass (BM25 normalized scores are < 1).
+	if len(results) != 0 {
+		t.Errorf("expected 0 results with MinScore=0.99, got %d", len(results))
+	}
+}
+
+func TestSearch_KeywordEmpty_FallsBackToFilesystem(t *testing.T) {
+	t.Parallel()
+
+	db, err := storage.Open(storage.OpenInput{InMemory: true})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := storage.Migrate(db); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	store := storage.NewStore(db)
+
+	// Seed a file so DetermineLevel returns Keyword (not Filesystem).
+	ctx := context.Background()
+	fileID, _ := store.UpsertFile(ctx, &types.FileRecord{
+		Path: "dummy.go", ContentHash: "h1", Mtime: 1.0,
+		EmbeddingStatus: "pending", ParseQuality: "full",
+	})
+	store.InsertChunks(ctx, fileID, []types.ChunkRecord{
+		{ChunkIndex: 0, Kind: "function", StartLine: 1, EndLine: 10,
+			Content: "func unrelated() {}", TokenCount: 5},
+	})
+
+	// Create a temp dir with a .go file for filesystem fallback.
+	tmpDir := t.TempDir()
+	os.WriteFile(filepath.Join(tmpDir, "hello.go"),
+		[]byte("package main\nfunc Hello() {}"), 0644)
+
+	engine := NewQueryEngine(store, tmpDir)
+
+	// Query for something that won't match any FTS content.
+	results, err := engine.Search(ctx, SearchInput{
+		Query:      "zzz_nonexistent_query_xyx",
+		MaxResults: 10,
+	})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+
+	// searchKeyword returns empty -> should fall back to filesystem.
+	if len(results) == 0 {
+		t.Error("expected filesystem fallback results when keyword search is empty")
+	}
+}
+
+func TestContext_KeywordEmpty_FallsBackToFilesystem(t *testing.T) {
+	t.Parallel()
+
+	db, err := storage.Open(storage.OpenInput{InMemory: true})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := storage.Migrate(db); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	store := storage.NewStore(db)
+
+	// Seed a file so DetermineLevel returns Keyword.
+	ctx := context.Background()
+	fileID, _ := store.UpsertFile(ctx, &types.FileRecord{
+		Path: "dummy.go", ContentHash: "h1", Mtime: 1.0,
+		EmbeddingStatus: "pending", ParseQuality: "full",
+	})
+	store.InsertChunks(ctx, fileID, []types.ChunkRecord{
+		{ChunkIndex: 0, Kind: "function", StartLine: 1, EndLine: 10,
+			Content: "func unrelated() {}", TokenCount: 5},
+	})
+
+	tmpDir := t.TempDir()
+	os.WriteFile(filepath.Join(tmpDir, "ctx.go"),
+		[]byte("package main\nfunc Context() {}"), 0644)
+
+	engine := NewQueryEngine(store, tmpDir)
+
+	pkg, err := engine.Context(ctx, ContextInput{
+		Query:        "zzz_nonexistent_query_xyx",
+		BudgetTokens: 4096,
+	})
+	if err != nil {
+		t.Fatalf("Context: %v", err)
+	}
+
+	if pkg == nil || len(pkg.Chunks) == 0 {
+		t.Error("expected filesystem fallback results for contextKeyword with empty keyword results")
+	}
+}
+
+func TestContext_SemanticEmpty_FallsBackToFilesystem(t *testing.T) {
+	t.Parallel()
+
+	db, err := storage.Open(storage.OpenInput{InMemory: true})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := storage.Migrate(db); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	store := storage.NewStore(db)
+
+	ctx := context.Background()
+	fileID, _ := store.UpsertFile(ctx, &types.FileRecord{
+		Path: "dummy.go", ContentHash: "h1", Mtime: 1.0,
+		EmbeddingStatus: "pending", ParseQuality: "full",
+	})
+	store.InsertChunks(ctx, fileID, []types.ChunkRecord{
+		{ChunkIndex: 0, Kind: "function", StartLine: 1, EndLine: 10,
+			Content: "func unrelated() {}", TokenCount: 5},
+	})
+
+	tmpDir := t.TempDir()
+	os.WriteFile(filepath.Join(tmpDir, "sem.go"),
+		[]byte("package main\nfunc Sem() {}"), 0644)
+
+	// Set up vector store so DetermineLevel picks hybrid/mixed,
+	// but use a query that returns no keyword or semantic results.
+	dim := 4
+	vs := vector.NewBruteForceStore(dim)
+	vs.Upsert(ctx, 1, []float32{0.1, 0.1, 0.1, 0.1})
+
+	embedder := newMockEmbedder(dim)
+	engine := NewQueryEngine(store, tmpDir)
+	engine.SetVectorStore(vs, embedder, func() bool { return true })
+
+	pkg, err := engine.Context(ctx, ContextInput{
+		Query:        "zzz_nonexistent_query_xyx",
+		BudgetTokens: 4096,
+	})
+	if err != nil {
+		t.Fatalf("Context: %v", err)
+	}
+
+	// contextSemantic should fall back to filesystem when results are empty.
+	if pkg == nil || len(pkg.Chunks) == 0 {
+		t.Error("expected filesystem fallback results for contextSemantic with empty results")
+	}
+}
+
+func TestSearch_DefaultMaxResults(t *testing.T) {
+	t.Parallel()
+	engine, store := setupTestEngine(t)
+	seedTestData(t, store)
+
+	ctx := context.Background()
+
+	// MaxResults=0 should default to 10.
+	results, err := engine.Search(ctx, SearchInput{
+		Query: "validate token",
+	})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+
+	// Should return results (default MaxResults=10).
+	if len(results) == 0 {
+		t.Error("expected results with default MaxResults")
+	}
 }

--- a/internal/core/fallback_test.go
+++ b/internal/core/fallback_test.go
@@ -1,0 +1,203 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFilesystemFallback_CancelledContext(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	// Create several .go files.
+	for i := 0; i < 10; i++ {
+		os.WriteFile(filepath.Join(dir, fmt.Sprintf("file%d.go", i)),
+			[]byte(fmt.Sprintf("package main\nfunc f%d() {}", i)), 0644)
+	}
+
+	// Cancel context immediately.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	pkg, err := FilesystemFallback(ctx, dir, "query", 4096)
+	// Should not error -- just return early with partial or empty results.
+	if err != nil {
+		t.Fatalf("FilesystemFallback: %v", err)
+	}
+	// With cancelled context, should have fewer results than total files.
+	if pkg != nil && len(pkg.Chunks) >= 10 {
+		t.Errorf("expected fewer chunks with cancelled context, got %d", len(pkg.Chunks))
+	}
+}
+
+func TestFilesystemFallback_EmptyDirectory(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	// Create only a non-source file.
+	os.WriteFile(filepath.Join(dir, "readme.txt"), []byte("hello"), 0644)
+
+	pkg, err := FilesystemFallback(context.Background(), dir, "query", 4096)
+	if err != nil {
+		t.Fatalf("FilesystemFallback: %v", err)
+	}
+	if pkg != nil && len(pkg.Chunks) != 0 {
+		t.Errorf("expected 0 chunks for directory with no source files, got %d", len(pkg.Chunks))
+	}
+}
+
+func TestFilesystemFallback_BudgetBoundary(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	// Create files with known sizes. Each char ~ 0.25 tokens, so 100 chars = 25 tokens.
+	os.WriteFile(filepath.Join(dir, "a.go"),
+		[]byte(fmt.Sprintf("package a\n%s", string(make([]byte, 96)))), 0644) // ~106 chars = 26 tokens
+	os.WriteFile(filepath.Join(dir, "b.go"),
+		[]byte(fmt.Sprintf("package b\n%s", string(make([]byte, 96)))), 0644) // ~106 chars = 26 tokens
+
+	// Budget of 30 tokens: should fit only 1 file (26 tokens), second truncated or skipped.
+	pkg, err := FilesystemFallback(context.Background(), dir, "query", 30)
+	if err != nil {
+		t.Fatalf("FilesystemFallback: %v", err)
+	}
+	if pkg == nil {
+		t.Fatal("expected non-nil package")
+	}
+	if pkg.TotalTokens > 30 {
+		t.Errorf("total tokens %d exceeds budget 30", pkg.TotalTokens)
+	}
+	if pkg.Strategy != "filesystem_l3" {
+		t.Errorf("expected strategy filesystem_l3, got %q", pkg.Strategy)
+	}
+}
+
+func TestFilesystemFallback_TruncatesLargeFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	// Create a large file (1000 chars = 250 tokens).
+	content := make([]byte, 1000)
+	for i := range content {
+		content[i] = 'x'
+	}
+	os.WriteFile(filepath.Join(dir, "big.go"), content, 0644)
+
+	// Budget of 50 tokens: file should be truncated to fit.
+	pkg, err := FilesystemFallback(context.Background(), dir, "query", 50)
+	if err != nil {
+		t.Fatalf("FilesystemFallback: %v", err)
+	}
+	if pkg == nil {
+		t.Fatal("expected non-nil package")
+	}
+	if pkg.TotalTokens > 50 {
+		t.Errorf("total tokens %d exceeds budget 50", pkg.TotalTokens)
+	}
+	if len(pkg.Chunks) != 1 {
+		t.Errorf("expected 1 chunk, got %d", len(pkg.Chunks))
+	}
+	if len(pkg.Chunks) > 0 && len(pkg.Chunks[0].Content) >= 1000 {
+		t.Error("expected content to be truncated")
+	}
+}
+
+func TestFilesystemFallback_SkipsVendorAndGit(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	// Create files in skipped directories.
+	vendorDir := filepath.Join(dir, "vendor")
+	os.Mkdir(vendorDir, 0755)
+	os.WriteFile(filepath.Join(vendorDir, "lib.go"),
+		[]byte("package vendor"), 0644)
+
+	gitDir := filepath.Join(dir, ".git")
+	os.Mkdir(gitDir, 0755)
+	os.WriteFile(filepath.Join(gitDir, "config.go"),
+		[]byte("package git"), 0644)
+
+	// Create a regular source file.
+	os.WriteFile(filepath.Join(dir, "main.go"),
+		[]byte("package main\nfunc main() {}"), 0644)
+
+	pkg, err := FilesystemFallback(context.Background(), dir, "query", 4096)
+	if err != nil {
+		t.Fatalf("FilesystemFallback: %v", err)
+	}
+	if pkg == nil {
+		t.Fatal("expected non-nil package")
+	}
+
+	// Should only find main.go, not vendor/ or .git/ files.
+	for _, c := range pkg.Chunks {
+		if c.Path == "vendor/lib.go" || c.Path == ".git/config.go" {
+			t.Errorf("should not include file from excluded directory: %s", c.Path)
+		}
+	}
+	if len(pkg.Chunks) != 1 {
+		t.Errorf("expected 1 chunk (main.go only), got %d", len(pkg.Chunks))
+	}
+}
+
+func TestFilesystemFallback_Symlink(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	// Create a real file and a symlink pointing to it.
+	os.WriteFile(filepath.Join(dir, "real.go"),
+		[]byte("package main\nfunc Real() {}"), 0644)
+
+	// Create symlink to a file within the project (should be included).
+	os.Symlink(filepath.Join(dir, "real.go"), filepath.Join(dir, "link.go"))
+
+	pkg, err := FilesystemFallback(context.Background(), dir, "query", 4096)
+	if err != nil {
+		t.Fatalf("FilesystemFallback: %v", err)
+	}
+	if pkg == nil {
+		t.Fatal("expected non-nil package")
+	}
+
+	// Both real.go and link.go should be included (link resolves within project root).
+	if len(pkg.Chunks) < 1 {
+		t.Error("expected at least 1 chunk")
+	}
+}
+
+func TestFilesystemFallback_InvalidRoot(t *testing.T) {
+	t.Parallel()
+
+	_, err := FilesystemFallback(context.Background(), "/nonexistent/path/that/does/not/exist", "query", 4096)
+	if err == nil {
+		t.Error("expected error for nonexistent project root")
+	}
+}
+
+func TestFilesystemFallback_MultipleExtensions(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	// Create files with various supported extensions.
+	os.WriteFile(filepath.Join(dir, "app.ts"), []byte("const x = 1;"), 0644)
+	os.WriteFile(filepath.Join(dir, "app.py"), []byte("x = 1"), 0644)
+	os.WriteFile(filepath.Join(dir, "app.rs"), []byte("fn main() {}"), 0644)
+	os.WriteFile(filepath.Join(dir, "app.java"), []byte("class App {}"), 0644)
+	os.WriteFile(filepath.Join(dir, "app.txt"), []byte("not code"), 0644) // should be skipped
+
+	pkg, err := FilesystemFallback(context.Background(), dir, "query", 4096)
+	if err != nil {
+		t.Fatalf("FilesystemFallback: %v", err)
+	}
+	if pkg == nil {
+		t.Fatal("expected non-nil package")
+	}
+
+	// Should have 4 chunks (ts, py, rs, java) but not txt.
+	if len(pkg.Chunks) != 4 {
+		t.Errorf("expected 4 chunks for supported extensions, got %d", len(pkg.Chunks))
+	}
+}

--- a/internal/core/ranker_test.go
+++ b/internal/core/ranker_test.go
@@ -4,6 +4,7 @@ package core
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"math"
 	"testing"
@@ -282,6 +283,211 @@ func TestHybridRank_WithSessionScorer(t *testing.T) {
 	// With session-only weights, ChunkID 2 should be first (score 0.95)
 	if got[0].ChunkID != 2 {
 		t.Errorf("expected ChunkID 2 first (high session score), got ChunkID %d", got[0].ChunkID)
+	}
+}
+
+func TestLookupSymbolForChunk_NoSymbol(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+	ctx := context.Background()
+
+	// Insert a file and a chunk with no SymbolName.
+	fileID, err := store.UpsertFile(ctx, &types.FileRecord{
+		Path: "nosym.go", ContentHash: "h1", Mtime: 1.0,
+		EmbeddingStatus: "pending", ParseQuality: "full",
+	})
+	if err != nil {
+		t.Fatalf("UpsertFile: %v", err)
+	}
+	chunkIDs, err := store.InsertChunks(ctx, fileID, []types.ChunkRecord{
+		{ChunkIndex: 0, SymbolName: "", Kind: "block",
+			StartLine: 1, EndLine: 10,
+			Content: "package main", TokenCount: 5},
+	})
+	if err != nil {
+		t.Fatalf("InsertChunks: %v", err)
+	}
+
+	id := lookupSymbolForChunk(ctx, store, chunkIDs[0])
+	if id != 0 {
+		t.Errorf("expected 0 for chunk with no symbol name, got %d", id)
+	}
+}
+
+func TestLookupChunkIDsForSymbols_UnknownID(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+
+	// Unknown symbol IDs should be silently skipped.
+	result := lookupChunkIDsForSymbols(context.Background(), store, []int64{99999})
+	if len(result) != 0 {
+		t.Errorf("expected 0 results for unknown IDs, got %d", len(result))
+	}
+}
+
+func TestComputeStructuralScores_WithGraphEdges(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+	ctx := context.Background()
+
+	// Create two files, each with 1 chunk and 1 symbol, connected by an edge.
+	fileID1, err := store.UpsertFile(ctx, &types.FileRecord{
+		Path: "a.go", ContentHash: "h1", Mtime: 1.0,
+		EmbeddingStatus: "pending", ParseQuality: "full",
+	})
+	if err != nil {
+		t.Fatalf("UpsertFile 1: %v", err)
+	}
+	chunkIDs1, err := store.InsertChunks(ctx, fileID1, []types.ChunkRecord{
+		{ChunkIndex: 0, SymbolName: "FuncA", Kind: "function",
+			StartLine: 1, EndLine: 10, Content: "func A() {}", TokenCount: 5},
+	})
+	if err != nil {
+		t.Fatalf("InsertChunks 1: %v", err)
+	}
+	symIDs1, err := store.InsertSymbols(ctx, fileID1, []types.SymbolRecord{
+		{ChunkID: chunkIDs1[0], Name: "FuncA", Kind: "function", Line: 1, Visibility: "exported"},
+	})
+	if err != nil {
+		t.Fatalf("InsertSymbols 1: %v", err)
+	}
+
+	fileID2, err := store.UpsertFile(ctx, &types.FileRecord{
+		Path: "b.go", ContentHash: "h2", Mtime: 1.0,
+		EmbeddingStatus: "pending", ParseQuality: "full",
+	})
+	if err != nil {
+		t.Fatalf("UpsertFile 2: %v", err)
+	}
+	chunkIDs2, err := store.InsertChunks(ctx, fileID2, []types.ChunkRecord{
+		{ChunkIndex: 0, SymbolName: "FuncB", Kind: "function",
+			StartLine: 1, EndLine: 10, Content: "func B() {}", TokenCount: 5},
+	})
+	if err != nil {
+		t.Fatalf("InsertChunks 2: %v", err)
+	}
+	symIDs2, err := store.InsertSymbols(ctx, fileID2, []types.SymbolRecord{
+		{ChunkID: chunkIDs2[0], Name: "FuncB", Kind: "function", Line: 1, Visibility: "exported"},
+	})
+	if err != nil {
+		t.Fatalf("InsertSymbols 2: %v", err)
+	}
+
+	// Insert a direct edge: FuncA -> FuncB
+	err = store.DB().WithWriteTx(func(tx *sql.Tx) error {
+		symMap := map[string]int64{
+			"FuncA": symIDs1[0],
+			"FuncB": symIDs2[0],
+		}
+		return store.InsertEdges(ctx, tx, fileID1, []types.EdgeRecord{
+			{SrcSymbolName: "FuncA", DstSymbolName: "FuncB", Kind: "calls"},
+		}, symMap)
+	})
+	if err != nil {
+		t.Fatalf("InsertEdges: %v", err)
+	}
+
+	candidates := []types.ScoredResult{
+		{ChunkID: chunkIDs1[0], Score: 0.9, Path: "a.go", SymbolName: "FuncA",
+			Kind: "function", StartLine: 1, EndLine: 10},
+		{ChunkID: chunkIDs2[0], Score: 0.8, Path: "b.go", SymbolName: "FuncB",
+			Kind: "function", StartLine: 1, EndLine: 10},
+	}
+
+	scores := computeStructuralScores(ctx, store, candidates)
+
+	// Both chunks should have non-zero structural scores because they are
+	// BFS-reachable neighbors and both appear in the candidate set.
+	if scores[chunkIDs1[0]] == 0 {
+		t.Error("expected non-zero structural score for FuncA (neighbor FuncB is a candidate)")
+	}
+	if scores[chunkIDs2[0]] == 0 {
+		t.Error("expected non-zero structural score for FuncB (neighbor FuncA is a candidate)")
+	}
+}
+
+func TestLookupSymbolForChunk_MatchingSymbol(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+	ctx := context.Background()
+
+	fileID, err := store.UpsertFile(ctx, &types.FileRecord{
+		Path: "sym.go", ContentHash: "h1", Mtime: 1.0,
+		EmbeddingStatus: "pending", ParseQuality: "full",
+	})
+	if err != nil {
+		t.Fatalf("UpsertFile: %v", err)
+	}
+	chunkIDs, err := store.InsertChunks(ctx, fileID, []types.ChunkRecord{
+		{ChunkIndex: 0, SymbolName: "MyFunc", Kind: "function",
+			StartLine: 1, EndLine: 10, Content: "func MyFunc() {}", TokenCount: 5},
+	})
+	if err != nil {
+		t.Fatalf("InsertChunks: %v", err)
+	}
+	symIDs, err := store.InsertSymbols(ctx, fileID, []types.SymbolRecord{
+		{ChunkID: chunkIDs[0], Name: "MyFunc", Kind: "function", Line: 1, Visibility: "exported"},
+	})
+	if err != nil {
+		t.Fatalf("InsertSymbols: %v", err)
+	}
+
+	got := lookupSymbolForChunk(ctx, store, chunkIDs[0])
+	if got != symIDs[0] {
+		t.Errorf("lookupSymbolForChunk = %d, want %d", got, symIDs[0])
+	}
+}
+
+func TestLookupSymbolForChunk_MatchesSameFile(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+	ctx := context.Background()
+
+	// Create two files, both with a symbol named "Handler".
+	// lookupSymbolForChunk should prefer the same-file symbol.
+	fileID1, err := store.UpsertFile(ctx, &types.FileRecord{
+		Path: "f1.go", ContentHash: "h1", Mtime: 1.0,
+		EmbeddingStatus: "pending", ParseQuality: "full",
+	})
+	if err != nil {
+		t.Fatalf("UpsertFile 1: %v", err)
+	}
+	chunkIDs1, err := store.InsertChunks(ctx, fileID1, []types.ChunkRecord{
+		{ChunkIndex: 0, SymbolName: "Handler", Kind: "function",
+			StartLine: 1, EndLine: 10, Content: "func Handler() {}", TokenCount: 5},
+	})
+	if err != nil {
+		t.Fatalf("InsertChunks 1: %v", err)
+	}
+	symIDs1, err := store.InsertSymbols(ctx, fileID1, []types.SymbolRecord{
+		{ChunkID: chunkIDs1[0], Name: "Handler", Kind: "function", Line: 1, Visibility: "exported"},
+	})
+	if err != nil {
+		t.Fatalf("InsertSymbols 1: %v", err)
+	}
+
+	fileID2, err := store.UpsertFile(ctx, &types.FileRecord{
+		Path: "f2.go", ContentHash: "h2", Mtime: 1.0,
+		EmbeddingStatus: "pending", ParseQuality: "full",
+	})
+	if err != nil {
+		t.Fatalf("UpsertFile 2: %v", err)
+	}
+	chunkIDs2, err := store.InsertChunks(ctx, fileID2, []types.ChunkRecord{
+		{ChunkIndex: 0, SymbolName: "Handler", Kind: "function",
+			StartLine: 1, EndLine: 10, Content: "func Handler() {}", TokenCount: 5},
+	})
+	if err != nil {
+		t.Fatalf("InsertChunks 2: %v", err)
+	}
+	store.InsertSymbols(ctx, fileID2, []types.SymbolRecord{
+		{ChunkID: chunkIDs2[0], Name: "Handler", Kind: "function", Line: 1, Visibility: "exported"},
+	})
+
+	// Lookup for file1's chunk should return file1's symbol
+	got := lookupSymbolForChunk(ctx, store, chunkIDs1[0])
+	if got != symIDs1[0] {
+		t.Errorf("lookupSymbolForChunk for file1 chunk = %d, want %d (same-file match)", got, symIDs1[0])
 	}
 }
 

--- a/internal/core/retrieval_test.go
+++ b/internal/core/retrieval_test.go
@@ -1,0 +1,52 @@
+//go:build sqlite_fts5
+
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/shaktimanai/shaktiman/internal/types"
+)
+
+func TestHydrateFTSResults_MissingChunk(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+	ctx := context.Background()
+
+	// Insert a real file and chunk.
+	fileID, err := store.UpsertFile(ctx, &types.FileRecord{
+		Path: "test.go", ContentHash: "h1", Mtime: 1.0,
+		EmbeddingStatus: "pending", ParseQuality: "full",
+	})
+	if err != nil {
+		t.Fatalf("UpsertFile: %v", err)
+	}
+	chunkIDs, err := store.InsertChunks(ctx, fileID, []types.ChunkRecord{
+		{ChunkIndex: 0, SymbolName: "funcA", Kind: "function",
+			StartLine: 1, EndLine: 10,
+			Content: "func A() {}", TokenCount: 5},
+	})
+	if err != nil {
+		t.Fatalf("InsertChunks: %v", err)
+	}
+
+	// Create FTS results: one valid, one with a nonexistent chunk ID.
+	ftsResults := []types.FTSResult{
+		{ChunkID: 99999, Rank: -10.0},      // Missing chunk -- should be skipped
+		{ChunkID: chunkIDs[0], Rank: -5.0},  // Valid chunk
+	}
+
+	results, err := hydrateFTSResults(ctx, store, ftsResults)
+	if err != nil {
+		t.Fatalf("hydrateFTSResults: %v", err)
+	}
+
+	// Only the valid chunk should be in results.
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result (skipping missing chunk), got %d", len(results))
+	}
+	if results[0].ChunkID != chunkIDs[0] {
+		t.Errorf("ChunkID = %d, want %d", results[0].ChunkID, chunkIDs[0])
+	}
+}

--- a/internal/core/session_test.go
+++ b/internal/core/session_test.go
@@ -205,6 +205,43 @@ func TestSessionStore_Concurrent(t *testing.T) {
 	}
 }
 
+func TestNewSessionStore_ZeroMaxSize(t *testing.T) {
+	t.Parallel()
+
+	// Zero maxSize should default to 2000.
+	ss := NewSessionStore(0)
+
+	// Insert 2001 entries; if maxSize=2000, the store should evict.
+	for i := 0; i < 2001; i++ {
+		ss.RecordAccess(fmt.Sprintf("file%d.go", i), i)
+	}
+	if ss.Len() > 2000 {
+		t.Errorf("Len() = %d, expected <= 2000 (default maxSize)", ss.Len())
+	}
+}
+
+func TestRecordBatch_ReAccess(t *testing.T) {
+	t.Parallel()
+
+	ss := NewSessionStore(100)
+
+	// First access.
+	ss.RecordBatch([]SessionHit{
+		{FilePath: "a.go", StartLine: 1},
+	})
+	s1 := ss.Score("a.go", 1)
+
+	// Second access to same key -- score should increase.
+	ss.RecordBatch([]SessionHit{
+		{FilePath: "a.go", StartLine: 1},
+	})
+	s2 := ss.Score("a.go", 1)
+
+	if s2 <= s1 {
+		t.Errorf("score after re-access (%f) should be > initial score (%f)", s2, s1)
+	}
+}
+
 // ── Benchmarks ──
 
 func BenchmarkSessionStore_Score(b *testing.B) {


### PR DESCRIPTION
Add integration tests for assembler, retrieval, fallback, session
 
Ranker, and engine covering budget fitting, line-overlap dedup, semantic/hybrid search, filesystem fallback, session scoring with  LRU eviction and decay, and hybrid ranking with structural/change signals. 
Remove 8 superficial tests (trivial no-op, getter, and duplicate tests) identified via code review.

Linked Issues. 
https://github.com/midhunkrishna/shaktiman/issues/1