### PR TITLE
fix(mismatch-embedding-count): incorrect embedding count shown

### DIFF
--- a/cmd/shaktiman/main.go
+++ b/cmd/shaktiman/main.go
@@ -105,9 +105,7 @@ func indexCmd() *cobra.Command {
 
 			if embed {
 				var lastEmbedPct int
-				var embedTotal int
 				count, err := d.EmbedProject(ctx, func(p types.EmbedProgress) {
-					embedTotal = p.Total
 					if p.Warning != "" {
 						if tty {
 							fmt.Fprintf(os.Stdout, "\r%s%s", p.Warning, strings.Repeat(" ", 20))
@@ -135,14 +133,14 @@ func indexCmd() *cobra.Command {
 					fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 					fmt.Fprintf(os.Stderr, "Indexing completed without embeddings. Run 'shaktiman index --embed' to retry.\n")
 					if count > 0 {
-						fmt.Printf("Embedded: %d chunks (partial) → %s\n", count, cfg.EmbeddingsPath)
+						fmt.Printf("Embedded: %d/%d chunks (partial) → %s\n", count, stats.TotalChunks, cfg.EmbeddingsPath)
 					}
 				} else {
-					if count < embedTotal && embedTotal > 0 {
-						fmt.Fprintf(os.Stderr, "Warning: %d/%d chunks could not be embedded (Ollama errors).\n", embedTotal-count, embedTotal)
+					if count < stats.TotalChunks && stats.TotalChunks > 0 {
+						fmt.Fprintf(os.Stderr, "Warning: %d/%d chunks could not be embedded (Ollama errors).\n", stats.TotalChunks-count, stats.TotalChunks)
 						fmt.Fprintf(os.Stderr, "Run 'shaktiman index --embed' to retry failed chunks.\n")
 					}
-					fmt.Printf("Embedded: %d chunks → %s\n", count, cfg.EmbeddingsPath)
+					fmt.Printf("Embedded: %d/%d chunks → %s\n", count, stats.TotalChunks, cfg.EmbeddingsPath)
 				}
 			}
 			return nil

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -264,6 +264,19 @@ func (d *Daemon) EmbedProject(ctx context.Context, onProgress func(types.EmbedPr
 		return 0, fmt.Errorf("Ollama is not reachable at %s", d.cfg.OllamaURL)
 	}
 
+	// Reverse reconciliation: if vector store has fewer vectors than DB claims
+	// are embedded, reset all embedded flags. This handles deleted/corrupted
+	// embeddings.bin where the DB is out of sync with the actual vectors.
+	embeddedInDB, _ := d.store.CountChunksEmbedded(ctx)
+	vectorCount, _ := d.vectorStore.Count(ctx)
+	if embeddedInDB > 0 && vectorCount < embeddedInDB {
+		d.logger.Info("vector store out of sync with DB, resetting embedded flags",
+			"db_embedded", embeddedInDB, "vector_count", vectorCount)
+		if err := d.store.ResetAllEmbeddedFlags(ctx); err != nil {
+			return 0, fmt.Errorf("reset embedded flags: %w", err)
+		}
+	}
+
 	count, err := d.embedFromDB(ctx, onProgress)
 
 	// Save embeddings even on partial failure (crash safety).

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1398,6 +1398,85 @@ func TestEmbedProject_CrashRecovery(t *testing.T) {
 	d2.Stop()
 }
 
+// TestEmbedProject_ReverseReconciliation verifies that when embeddings.bin is
+// deleted but the DB still has chunks marked embedded=1, EmbedProject detects
+// the mismatch and re-embeds all chunks.
+//
+// Invariant: the embedded column in SQLite must stay in sync with the actual
+// vector store contents. If vectors are lost, the DB must be corrected.
+func TestEmbedProject_ReverseReconciliation(t *testing.T) {
+	t.Parallel()
+
+	const dims = 4
+	srv := newMockOllama(dims, nil)
+	defer srv.Close()
+
+	tmpDir := t.TempDir()
+	projectDir := filepath.Join(tmpDir, "project")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	writeGoFiles(t, projectDir, 3, 3)
+
+	dbPath := filepath.Join(tmpDir, "test.db")
+	embPath := filepath.Join(tmpDir, "embeddings.bin")
+	cfg := embedCfg(projectDir, dbPath, embPath, srv.URL)
+
+	ctx := context.Background()
+
+	// Phase 1: Index + embed all chunks.
+	d1, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New daemon (phase 1): %v", err)
+	}
+	if err := d1.IndexProject(ctx, nil); err != nil {
+		t.Fatalf("IndexProject (phase 1): %v", err)
+	}
+	count1, err := d1.EmbedProject(ctx, nil)
+	if err != nil {
+		t.Fatalf("EmbedProject (phase 1): %v", err)
+	}
+	if count1 == 0 {
+		t.Fatal("expected non-zero vector count after phase 1")
+	}
+	need, _ := d1.Store().CountChunksNeedingEmbedding(ctx)
+	if need != 0 {
+		t.Fatalf("expected 0 chunks needing embedding after phase 1, got %d", need)
+	}
+	t.Logf("Phase 1: embedded %d vectors", count1)
+	d1.Stop()
+
+	// Phase 2: Delete embeddings.bin (simulate user deleting the file).
+	if err := os.Remove(embPath); err != nil {
+		t.Fatalf("Remove embeddings.bin: %v", err)
+	}
+
+	// Phase 3: Re-create daemon (same DB, no embeddings.bin) and re-embed.
+	d2, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New daemon (phase 3): %v", err)
+	}
+
+	count2, err := d2.EmbedProject(ctx, nil)
+	if err != nil {
+		t.Fatalf("EmbedProject (phase 3): %v", err)
+	}
+	t.Logf("Phase 3: embedded %d vectors (expected %d)", count2, count1)
+
+	// All chunks must be re-embedded — vector count should match phase 1.
+	if count2 != count1 {
+		t.Errorf("vector count after re-embed = %d, want %d (all chunks re-embedded)", count2, count1)
+	}
+
+	// No chunks should be left needing embedding.
+	need, _ = d2.Store().CountChunksNeedingEmbedding(ctx)
+	if need != 0 {
+		t.Errorf("chunks needing embedding after re-embed = %d, want 0", need)
+	}
+
+	d2.Stop()
+}
+
 func TestEmbedProject_IncrementalAfterCold(t *testing.T) {
 	t.Parallel()
 

--- a/internal/storage/metadata.go
+++ b/internal/storage/metadata.go
@@ -434,6 +434,32 @@ func (s *Store) CountChunksNeedingEmbedding(ctx context.Context) (int, error) {
 	return count, nil
 }
 
+// CountChunksEmbedded returns the number of chunks with embedded = 1.
+func (s *Store) CountChunksEmbedded(ctx context.Context) (int, error) {
+	var count int
+	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM chunks WHERE embedded = 1`).Scan(&count); err != nil {
+		return 0, fmt.Errorf("count embedded chunks: %w", err)
+	}
+	return count, nil
+}
+
+// ResetAllEmbeddedFlags sets all chunks to embedded = 0 and all files to
+// embedding_status = 'pending'. Used when the vector store is out of sync
+// with the DB (e.g. embeddings.bin was deleted).
+func (s *Store) ResetAllEmbeddedFlags(ctx context.Context) error {
+	return s.db.WithWriteTx(func(tx *sql.Tx) error {
+		if _, err := tx.ExecContext(ctx,
+			`UPDATE chunks SET embedded = 0 WHERE embedded = 1`); err != nil {
+			return fmt.Errorf("reset embedded flags: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx,
+			`UPDATE files SET embedding_status = 'pending' WHERE embedding_status != 'pending'`); err != nil {
+			return fmt.Errorf("reset file embedding status: %w", err)
+		}
+		return nil
+	})
+}
+
 // MarkChunksEmbedded marks individual chunks as embedded and updates the parent
 // file's embedding_status based on cumulative progress. Files where all chunks
 // are now embedded get status 'complete'; files with some embedded get 'partial'.

--- a/internal/storage/metadata_test.go
+++ b/internal/storage/metadata_test.go
@@ -427,6 +427,128 @@ func TestCountChunksNeedingEmbedding(t *testing.T) {
 	}
 }
 
+func TestCountChunksEmbedded(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+	ctx := context.Background()
+
+	_, chunkIDs := insertTestFileWithChunks(t, store, "test.go", 50)
+
+	// Initially no chunks are embedded.
+	count, err := store.CountChunksEmbedded(ctx)
+	if err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("count = %d, want 0", count)
+	}
+
+	// Mark 20 as embedded.
+	if err := store.MarkChunksEmbedded(ctx, chunkIDs[:20]); err != nil {
+		t.Fatalf("MarkChunksEmbedded: %v", err)
+	}
+	count, err = store.CountChunksEmbedded(ctx)
+	if err != nil {
+		t.Fatalf("count after mark 20: %v", err)
+	}
+	if count != 20 {
+		t.Fatalf("count = %d, want 20", count)
+	}
+
+	// Mark remaining 30 — should be complementary to CountChunksNeedingEmbedding.
+	if err := store.MarkChunksEmbedded(ctx, chunkIDs[20:]); err != nil {
+		t.Fatalf("MarkChunksEmbedded: %v", err)
+	}
+	count, err = store.CountChunksEmbedded(ctx)
+	if err != nil {
+		t.Fatalf("count after mark all: %v", err)
+	}
+	if count != 50 {
+		t.Fatalf("count = %d, want 50", count)
+	}
+	need, err := store.CountChunksNeedingEmbedding(ctx)
+	if err != nil {
+		t.Fatalf("CountChunksNeedingEmbedding: %v", err)
+	}
+	if need != 0 {
+		t.Fatalf("need = %d, want 0", need)
+	}
+}
+
+// TestResetAllEmbeddedFlags verifies that ResetAllEmbeddedFlags sets all chunks
+// to embedded=0 and all files to embedding_status='pending'.
+func TestResetAllEmbeddedFlags(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+	ctx := context.Background()
+
+	// Insert two files with chunks.
+	_, chunkIDs1 := insertTestFileWithChunks(t, store, "a.go", 30)
+	_, chunkIDs2 := insertTestFileWithChunks(t, store, "b.go", 20)
+	allIDs := append(chunkIDs1, chunkIDs2...)
+
+	// Mark all as embedded → files become 'complete'.
+	if err := store.MarkChunksEmbedded(ctx, allIDs); err != nil {
+		t.Fatalf("MarkChunksEmbedded: %v", err)
+	}
+	embedded, _ := store.CountChunksEmbedded(ctx)
+	if embedded != 50 {
+		t.Fatalf("embedded = %d, want 50", embedded)
+	}
+	for _, path := range []string{"a.go", "b.go"} {
+		f, _ := store.GetFileByPath(ctx, path)
+		if f.EmbeddingStatus != "complete" {
+			t.Fatalf("%s status = %q, want 'complete'", path, f.EmbeddingStatus)
+		}
+	}
+
+	// Reset all flags.
+	if err := store.ResetAllEmbeddedFlags(ctx); err != nil {
+		t.Fatalf("ResetAllEmbeddedFlags: %v", err)
+	}
+
+	// All chunks back to embedded=0.
+	embedded, _ = store.CountChunksEmbedded(ctx)
+	if embedded != 0 {
+		t.Fatalf("embedded after reset = %d, want 0", embedded)
+	}
+	need, _ := store.CountChunksNeedingEmbedding(ctx)
+	if need != 50 {
+		t.Fatalf("need after reset = %d, want 50", need)
+	}
+
+	// All files back to 'pending'.
+	for _, path := range []string{"a.go", "b.go"} {
+		f, _ := store.GetFileByPath(ctx, path)
+		if f.EmbeddingStatus != "pending" {
+			t.Fatalf("%s status after reset = %q, want 'pending'", path, f.EmbeddingStatus)
+		}
+	}
+}
+
+// TestResetAllEmbeddedFlags_NoOp verifies that ResetAllEmbeddedFlags is safe
+// when no chunks are embedded.
+func TestResetAllEmbeddedFlags_NoOp(t *testing.T) {
+	t.Parallel()
+	store := setupTestStore(t)
+	ctx := context.Background()
+
+	_, _ = insertTestFileWithChunks(t, store, "clean.go", 10)
+
+	if err := store.ResetAllEmbeddedFlags(ctx); err != nil {
+		t.Fatalf("ResetAllEmbeddedFlags: %v", err)
+	}
+
+	need, _ := store.CountChunksNeedingEmbedding(ctx)
+	if need != 10 {
+		t.Fatalf("need = %d, want 10", need)
+	}
+	embedded, _ := store.CountChunksEmbedded(ctx)
+	if embedded != 0 {
+		t.Fatalf("embedded = %d, want 0", embedded)
+	}
+}
+
 func TestMarkChunksEmbedded_Cumulative(t *testing.T) {
 	t.Parallel()
 	store := setupTestStore(t)


### PR DESCRIPTION
if the embedding.bin is deleted without clearing sqlite dbs, then the system skips embedding as the sqlite db keeps track of the chunks embedded