### PR TITLE
feat(cli): add signal handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ build/
 .shaktiman/
 /shaktiman
 /shaktimand
+/bin/
 
 # go specific
 # If you prefer the allow list template instead of the deny list, see community template:

--- a/cmd/shaktiman/main.go
+++ b/cmd/shaktiman/main.go
@@ -7,7 +7,10 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"os/signal"
+	"path/filepath"
 	"strings"
+	"syscall"
 
 	"github.com/spf13/cobra"
 
@@ -37,6 +40,7 @@ func main() {
 	rootCmd.PersistentFlags().StringVar(&outputFormat, "format", "json",
 		`Output format: "json" (default) or "text"`)
 
+	rootCmd.AddCommand(initCmd())
 	rootCmd.AddCommand(indexCmd())
 	rootCmd.AddCommand(statusCmd())
 	rootCmd.AddCommand(searchCmd())
@@ -51,8 +55,33 @@ func main() {
 	}
 }
 
+func initCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "init <project-root>",
+		Short: "Initialize a .shaktiman config directory",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			projectRoot := args[0]
+			tomlPath := filepath.Join(projectRoot, ".shaktiman", "shaktiman.toml")
+			if _, err := os.Stat(tomlPath); err == nil {
+				fmt.Printf("Config already exists: %s\n", tomlPath)
+				return nil
+			}
+			types.WriteSampleConfig(projectRoot)
+			if _, err := os.Stat(tomlPath); err != nil {
+				return fmt.Errorf("failed to create config: %w", err)
+			}
+			fmt.Printf("Created config: %s\n", tomlPath)
+			return nil
+		},
+	}
+}
+
 func indexCmd() *cobra.Command {
-	var embed bool
+	var (
+		embed         bool
+		vectorBackend string
+	)
 	cmd := &cobra.Command{
 		Use:   "index <project-root>",
 		Short: "Index a project directory",
@@ -61,12 +90,30 @@ func indexCmd() *cobra.Command {
 			projectRoot := args[0]
 			cfg := types.DefaultConfig(projectRoot)
 
+			// Load TOML config if it exists
+			cfg, err := types.LoadConfigFromFile(cfg)
+			if err != nil {
+				return fmt.Errorf("load config: %w", err)
+			}
+
+			// CLI --vector flag overrides TOML and default
+			if vectorBackend != "" {
+				if vectorBackend != "brute_force" && vectorBackend != "hnsw" {
+					return fmt.Errorf("--vector must be 'brute_force' or 'hnsw', got %q", vectorBackend)
+				}
+				cfg.VectorBackend = vectorBackend
+			}
+
+			// Signal handling for graceful shutdown
+			ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+			defer stop()
+
 			d, err := daemon.New(cfg)
 			if err != nil {
 				return fmt.Errorf("init: %w", err)
 			}
+			defer d.Stop()
 
-			ctx := context.Background()
 			tty := isTTY()
 
 			// Index with progress
@@ -104,6 +151,10 @@ func indexCmd() *cobra.Command {
 			}
 
 			if embed {
+				// Start periodic embedding checkpoint saves
+				saveCtx, saveCancel := context.WithCancel(ctx)
+				go d.RunPeriodicEmbeddingSave(saveCtx)
+
 				var lastEmbedPct int
 				count, err := d.EmbedProject(ctx, func(p types.EmbedProgress) {
 					if p.Warning != "" {
@@ -125,11 +176,12 @@ func indexCmd() *cobra.Command {
 						lastEmbedPct = pct
 					}
 				})
+				saveCancel() // stop periodic saves
+
 				if tty {
 					fmt.Fprintln(os.Stdout)
 				}
 				if err != nil {
-					// Ollama unreachable: print friendly message and continue
 					fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 					fmt.Fprintf(os.Stderr, "Indexing completed without embeddings. Run 'shaktiman index --embed' to retry.\n")
 					if count > 0 {
@@ -147,6 +199,7 @@ func indexCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVar(&embed, "embed", false, "Also generate embeddings (requires Ollama)")
+	cmd.Flags().StringVar(&vectorBackend, "vector", "", `Vector backend: "brute_force" or "hnsw"`)
 	return cmd
 }
 

--- a/cmd/shaktiman/main_test.go
+++ b/cmd/shaktiman/main_test.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/shaktimanai/shaktiman/internal/types"
+)
+
+func TestInitCmd_CreatesConfig(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	tomlPath := filepath.Join(tmpDir, ".shaktiman", "shaktiman.toml")
+
+	cmd := initCmd()
+	cmd.SetArgs([]string{tmpDir})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("initCmd: %v", err)
+	}
+
+	if _, err := os.Stat(tomlPath); os.IsNotExist(err) {
+		t.Fatal("expected shaktiman.toml to be created")
+	}
+}
+
+func TestInitCmd_ExistingConfigNoOverwrite(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	dir := filepath.Join(tmpDir, ".shaktiman")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	tomlPath := filepath.Join(dir, "shaktiman.toml")
+	original := []byte("# my custom config\n")
+	if err := os.WriteFile(tomlPath, original, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := initCmd()
+	cmd.SetArgs([]string{tmpDir})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("initCmd: %v", err)
+	}
+
+	data, err := os.ReadFile(tomlPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != string(original) {
+		t.Error("expected existing config to be preserved")
+	}
+}
+
+func TestIndexCmd_LoadsTOML(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	dir := filepath.Join(tmpDir, ".shaktiman")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write a TOML with hnsw backend
+	toml := `[vector]
+backend = "hnsw"
+`
+	if err := os.WriteFile(filepath.Join(dir, "shaktiman.toml"), []byte(toml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := types.DefaultConfig(tmpDir)
+	cfg, err := types.LoadConfigFromFile(cfg)
+	if err != nil {
+		t.Fatalf("LoadConfigFromFile: %v", err)
+	}
+
+	if cfg.VectorBackend != "hnsw" {
+		t.Errorf("expected VectorBackend=hnsw, got %q", cfg.VectorBackend)
+	}
+}
+
+func TestIndexCmd_VectorFlagOverridesToml(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	dir := filepath.Join(tmpDir, ".shaktiman")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// TOML says brute_force
+	toml := `[vector]
+backend = "brute_force"
+`
+	if err := os.WriteFile(filepath.Join(dir, "shaktiman.toml"), []byte(toml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate what indexCmd does: load TOML then apply flag override
+	cfg := types.DefaultConfig(tmpDir)
+	cfg, err := types.LoadConfigFromFile(cfg)
+	if err != nil {
+		t.Fatalf("LoadConfigFromFile: %v", err)
+	}
+
+	// CLI --vector flag override
+	vectorBackend := "hnsw"
+	cfg.VectorBackend = vectorBackend
+
+	if cfg.VectorBackend != "hnsw" {
+		t.Errorf("expected --vector flag to override TOML, got %q", cfg.VectorBackend)
+	}
+}
+
+func TestIndexCmd_InvalidVectorFlag(t *testing.T) {
+	t.Parallel()
+
+	cmd := indexCmd()
+	cmd.SetArgs([]string{"--vector", "invalid", "/nonexistent"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for invalid --vector value")
+	}
+}

--- a/cmd/shaktiman/query.go
+++ b/cmd/shaktiman/query.go
@@ -179,6 +179,10 @@ func symbolsCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg := types.DefaultConfig(root)
+			cfg, err := types.LoadConfigFromFile(cfg)
+			if err != nil {
+				return fmt.Errorf("load config: %w", err)
+			}
 
 			db, err := storage.Open(storage.OpenInput{Path: cfg.DBPath})
 			if err != nil {
@@ -240,6 +244,10 @@ func depsCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg := types.DefaultConfig(root)
+			cfg, err := types.LoadConfigFromFile(cfg)
+			if err != nil {
+				return fmt.Errorf("load config: %w", err)
+			}
 
 			db, err := storage.Open(storage.OpenInput{Path: cfg.DBPath})
 			if err != nil {
@@ -322,6 +330,10 @@ func diffCmd() *cobra.Command {
 		Short: "Show recent file changes and affected symbols",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg := types.DefaultConfig(root)
+			cfg, err := types.LoadConfigFromFile(cfg)
+			if err != nil {
+				return fmt.Errorf("load config: %w", err)
+			}
 
 			db, err := storage.Open(storage.OpenInput{Path: cfg.DBPath})
 			if err != nil {
@@ -393,6 +405,10 @@ func enrichmentStatusCmd() *cobra.Command {
 		Short: "Show indexing stats and enrichment progress",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg := types.DefaultConfig(root)
+			cfg, err := types.LoadConfigFromFile(cfg)
+			if err != nil {
+				return fmt.Errorf("load config: %w", err)
+			}
 
 			db, err := storage.Open(storage.OpenInput{Path: cfg.DBPath})
 			if err != nil {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -337,6 +337,15 @@ func (d *Daemon) reconcileEmbeddedFlags(ctx context.Context) error {
 	return d.store.ResetEmbeddedFlags(ctx, missing)
 }
 
+// RunPeriodicEmbeddingSave is an exported wrapper around periodicEmbeddingSave.
+// Used by the CLI to run periodic checkpoint saves during embedding.
+func (d *Daemon) RunPeriodicEmbeddingSave(ctx context.Context) {
+	if d.vectorStore == nil {
+		return
+	}
+	d.periodicEmbeddingSave(ctx)
+}
+
 // periodicEmbeddingSave checkpoints embeddings to disk. Uses 30s interval during
 // active embedding (crash safety) and 5min interval otherwise. A short poll
 // interval detects embedding-active transitions without waiting for a full 5min tick.

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -510,6 +510,133 @@ func TestPeriodicEmbeddingSave(t *testing.T) {
 	d.Stop()
 }
 
+func TestRunPeriodicEmbeddingSave(t *testing.T) {
+	t.Parallel()
+
+	const dims = 4
+	srv := newMockOllama(dims, nil)
+	defer srv.Close()
+
+	tmpDir := t.TempDir()
+	projectDir := filepath.Join(tmpDir, "project")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeGoFiles(t, projectDir, 2, 2)
+
+	dbPath := filepath.Join(tmpDir, "test.db")
+	embPath := filepath.Join(tmpDir, "embeddings.bin")
+	cfg := embedCfg(projectDir, dbPath, embPath, srv.URL)
+
+	d, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx := context.Background()
+
+	if err := d.IndexProject(ctx, nil); err != nil {
+		t.Fatalf("IndexProject: %v", err)
+	}
+	if _, err := d.EmbedProject(ctx, nil); err != nil {
+		t.Fatalf("EmbedProject: %v", err)
+	}
+
+	// Remove saved file so we can verify RunPeriodicEmbeddingSave creates it
+	os.Remove(embPath)
+
+	d.savePollInterval = 5 * time.Millisecond
+	d.saveActiveInterval = 1 * time.Millisecond
+	d.saveIdleInterval = 1 * time.Millisecond
+	d.embeddingActive.Store(true)
+
+	saveCtx, saveCancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		d.RunPeriodicEmbeddingSave(saveCtx)
+		close(done)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	saveCancel()
+	<-done
+
+	if _, err := os.Stat(embPath); os.IsNotExist(err) {
+		t.Error("expected RunPeriodicEmbeddingSave to create embeddings file")
+	}
+
+	d.Stop()
+}
+
+func TestRunPeriodicEmbeddingSave_NilVectorStore(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.db")
+	cfg := types.Config{
+		ProjectRoot:       tmpDir,
+		DBPath:            dbPath,
+		EnrichmentWorkers: 2,
+		WriterChannelSize: 100,
+		EmbedEnabled:      false, // no vector store
+	}
+
+	d, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer d.Stop()
+
+	// Should return immediately without panic
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	d.RunPeriodicEmbeddingSave(ctx)
+}
+
+func TestStopSavesEmbeddings(t *testing.T) {
+	t.Parallel()
+
+	const dims = 4
+	srv := newMockOllama(dims, nil)
+	defer srv.Close()
+
+	tmpDir := t.TempDir()
+	projectDir := filepath.Join(tmpDir, "project")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeGoFiles(t, projectDir, 2, 2)
+
+	dbPath := filepath.Join(tmpDir, "test.db")
+	embPath := filepath.Join(tmpDir, "embeddings.bin")
+	cfg := embedCfg(projectDir, dbPath, embPath, srv.URL)
+
+	d, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := d.IndexProject(ctx, nil); err != nil {
+		t.Fatalf("IndexProject: %v", err)
+	}
+	if _, err := d.EmbedProject(ctx, nil); err != nil {
+		t.Fatalf("EmbedProject: %v", err)
+	}
+
+	// Remove the file saved by EmbedProject
+	os.Remove(embPath)
+
+	// Stop should save embeddings
+	if err := d.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+
+	if _, err := os.Stat(embPath); os.IsNotExist(err) {
+		t.Error("expected Stop() to save embeddings file")
+	}
+}
+
 // ── Language Compatibility Integration Tests ──
 //
 // These tests exercise the full pipeline (scan → parse → index → search)


### PR DESCRIPTION
feat(cli): add signal handling, TOML config loading, --vector flag, and init command

Ctrl+C during `shaktiman index --embed` now saves embedding progress instead of losing it. The CLI loads shaktiman.toml (like the MCP daemon already does), respects `--vector` flag to select brute_force or hnsw at index time, and gains a `shaktiman init` command to scaffold the config before first index. Periodic embedding checkpoints run during the embed phase so partial progress survives interruption.