### PR TITLE
fix(edges): add Rust import handler, fix symbolIDs map collision

### DIFF
--- a/internal/daemon/writer.go
+++ b/internal/daemon/writer.go
@@ -340,7 +340,12 @@ func processEnrichmentJob(ctx context.Context, tx *sql.Tx, store *storage.Store,
 			return nil, fmt.Errorf("insert symbol %s: %w", sym.Name, err)
 		}
 		symID, _ := res.LastInsertId()
-		symbolIDs[sym.Name] = symID
+		// Keep the first symbol ID for each name. Duplicates (e.g. Java
+		// method overloads) would overwrite, potentially pointing edges
+		// at the wrong overload.
+		if _, exists := symbolIDs[sym.Name]; !exists {
+			symbolIDs[sym.Name] = symID
+		}
 		newSymbolNames = append(newSymbolNames, sym.Name)
 	}
 

--- a/internal/parser/edges.go
+++ b/internal/parser/edges.go
@@ -149,6 +149,8 @@ func (p *Parser) extractImportEdgesFrom(node *sitter.Node, owner string, ctx *ed
 		p.javaImportEdges(node, owner, ctx)
 	case "groovy":
 		p.groovyImportEdges(node, owner, ctx)
+	case "rust":
+		p.rustImportEdges(node, owner, ctx)
 	// bash has no imports
 	}
 }
@@ -264,6 +266,42 @@ func (p *Parser) groovyImportEdges(node *sitter.Node, owner string, ctx *edgeCon
 			content := n.Content(ctx.source)
 			parts := strings.Split(content, ".")
 			ctx.addEdge(owner, parts[len(parts)-1], "imports")
+			return
+		}
+		for i := 0; i < int(n.NamedChildCount()); i++ {
+			walk(n.NamedChild(i))
+		}
+	}
+	walk(node)
+}
+
+func (p *Parser) rustImportEdges(node *sitter.Node, owner string, ctx *edgeContext) {
+	// Rust: use std::collections::HashMap; → extract "HashMap"
+	// Also handles: use std::{io, fs}; (use_list) and use foo as bar (use_as_clause)
+	var walk func(n *sitter.Node)
+	walk = func(n *sitter.Node) {
+		switch n.Type() {
+		case "use_as_clause":
+			// use foo::Bar as Baz → extract the alias "Baz"
+			alias := n.ChildByFieldName("alias")
+			if alias != nil {
+				ctx.addEdge(owner, alias.Content(ctx.source), "imports")
+				return
+			}
+			// No alias field, fall through to extract the path's last component
+		case "scoped_identifier":
+			name := n.ChildByFieldName("name")
+			if name != nil {
+				ctx.addEdge(owner, name.Content(ctx.source), "imports")
+			}
+			return
+		case "identifier":
+			ctx.addEdge(owner, n.Content(ctx.source), "imports")
+			return
+		case "scoped_use_list":
+			// use std::{io, fs}; → recurse into the use_list child
+		case "use_wildcard":
+			// use foo::*; → skip, no specific name to extract
 			return
 		}
 		for i := 0; i < int(n.NamedChildCount()); i++ {

--- a/internal/parser/edges_test.go
+++ b/internal/parser/edges_test.go
@@ -325,3 +325,80 @@ func TestEdges_GoCalls(t *testing.T) {
 		t.Error("expected a 'calls' edge targeting 'helper'")
 	}
 }
+
+// ── Rust import tests ──
+
+func TestEdges_RustImports(t *testing.T) {
+	t.Parallel()
+
+	p, err := NewParser()
+	if err != nil {
+		t.Fatalf("NewParser: %v", err)
+	}
+	defer p.Close()
+
+	src := []byte(`use std::collections::HashMap;
+use std::io;
+
+fn main() {
+    let map: HashMap<String, String> = HashMap::new();
+}
+`)
+
+	result, err := p.Parse(context.Background(), ParseInput{
+		FilePath: "main.rs",
+		Content:  src,
+		Language: "rust",
+	})
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	imports := map[string]bool{}
+	for _, e := range result.Edges {
+		if e.Kind == "imports" {
+			imports[e.DstSymbolName] = true
+		}
+	}
+	for _, name := range []string{"HashMap", "io"} {
+		if !imports[name] {
+			t.Errorf("expected import edge for %q, got imports: %v", name, imports)
+		}
+	}
+}
+
+func TestEdges_RustUseList(t *testing.T) {
+	t.Parallel()
+
+	p, err := NewParser()
+	if err != nil {
+		t.Fatalf("NewParser: %v", err)
+	}
+	defer p.Close()
+
+	src := []byte(`use std::{fs, io};
+
+fn process() {}
+`)
+
+	result, err := p.Parse(context.Background(), ParseInput{
+		FilePath: "lib.rs",
+		Content:  src,
+		Language: "rust",
+	})
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	imports := map[string]bool{}
+	for _, e := range result.Edges {
+		if e.Kind == "imports" {
+			imports[e.DstSymbolName] = true
+		}
+	}
+	for _, name := range []string{"fs", "io"} {
+		if !imports[name] {
+			t.Errorf("expected import edge for %q, got imports: %v", name, imports)
+		}
+	}
+}


### PR DESCRIPTION
Pre-existing issues found during adversarial analysis of the import edge fix:

- Add rustImportEdges handler for use_declaration parsing. Rust had use_declaration in ImportTypes but no case in extractImportEdgesFrom, so all Rust use statements were silently swallowed. Handles scoped identifiers, use lists (use std::{fs, io}), and use-as aliases.

- Fix symbolIDs map last-write-wins on duplicate names. Java method overloads or Go methods on different types with the same name would overwrite earlier entries, potentially pointing edges at the wrong symbol. Now keeps the first symbol ID for each name.