### PR TITLE
fix(edges): add qualified names and language filtering to prevent cro…

### DIFF
--- a/docs/planning/09-symbol-collision.md
+++ b/docs/planning/09-symbol-collision.md
@@ -1,0 +1,307 @@
+# Pending Edge Symbol Collision & Cross-Language Misresolution
+
+> Plan for fixing two related issues in the edge resolution pipeline:
+> (1) short-name collisions in `pending_edges`, and
+> (2) cross-language misresolution where a Java import can resolve to a Python class.
+
+---
+
+## 0. Problem Statement
+
+### 0.1 Short-Name Collision
+
+`pending_edges.dst_symbol_name` stores only the short name of unresolved import
+targets (e.g. `"List"` instead of `"java.util.List"`). When querying by short
+name, all pending edges with that name match regardless of package origin.
+
+| Scenario | What happens |
+|---|---|
+| Java imports `java.util.List` and guava's `ImmutableList` | Different short names, no collision |
+| Java imports `java.util.List`, another lib also exports `List` | Both stored as `"List"`, queries return mixed results |
+| Project defines its own `List` class | `ResolvePendingEdges` resolves `java.util.List` import to the project's `List` — wrong symbol |
+
+### 0.2 Cross-Language Misresolution
+
+`ResolvePendingEdges` and `lookupSymbolIDTx` do pure name-based lookup with no
+language filter:
+
+```go
+// lookupSymbolIDTx — no language constraint
+err := tx.QueryRowContext(ctx,
+    "SELECT id FROM symbols WHERE name = ? LIMIT 1", name).Scan(&id)
+```
+
+If a Python file defines `class Config` and a Java file has
+`import com.example.Config`, the Java import edge can resolve to the Python
+class's symbol ID. The `LIMIT 1` makes this nondeterministic — whichever row
+SQLite returns first wins.
+
+This also affects `ResolvePendingEdges`: when a new symbol is inserted, ALL
+pending edges with a matching `dst_symbol_name` are resolved to it, regardless
+of source language.
+
+### 0.3 Combined Impact
+
+In a polyglot monorepo (the reported use case: 6k Java, 1k JS, 500 Python,
+1k TypeScript files), common type names like `List`, `Config`, `Client`,
+`Handler`, `Builder`, `Error`, `Result` are defined across multiple languages.
+Both issues compound: a Java `Config` import resolves to whichever `Config`
+symbol was indexed first, which might be from a Python, TypeScript, or Go file.
+
+---
+
+## 1. Current Data Flow
+
+```
+Parser (edges.go)
+  javaImportEdges: "import java.util.List;" → addEdge(owner, "List", "imports")
+                                                       short name only ──┘
+                                                       no language tag ──┘
+    │
+    ▼
+Writer (writer.go)
+  InsertEdges:
+    srcID = symbolIDs["MyService"]     ← resolved within same file
+    dstID = lookupSymbolIDTx("List")   ← global lookup, no language filter
+      found?  → edges(src_symbol_id, dst_symbol_id)  ← may be wrong symbol
+      !found? → pending_edges(src_symbol_id, "List")  ← no qualified name
+    │
+    ▼
+ResolvePendingEdges (on future file index):
+  SELECT FROM pending_edges WHERE dst_symbol_name IN ('Config', 'List', ...)
+    ← matches ALL pending edges with these names across ALL languages
+  lookupSymbolIDTx("List", 0)
+    ← LIMIT 1, no language filter — returns arbitrary match
+```
+
+---
+
+## 2. Proposed Fix
+
+Two changes that work together:
+
+### 2.1 Add Qualified Name to EdgeRecord and pending_edges
+
+Each language's import handler extracts the full import path alongside the short
+name. This disambiguates `java.util.List` from `com.example.List` at the data
+level.
+
+**Schema (v2 → v3):**
+
+```sql
+ALTER TABLE pending_edges ADD COLUMN dst_qualified_name TEXT DEFAULT '';
+```
+
+**EdgeRecord type:**
+
+```go
+type EdgeRecord struct {
+    // ... existing fields ...
+    DstQualifiedName string // e.g. "java.util.List", "fmt", "std::collections::HashMap"
+}
+```
+
+**Parser — new helper and per-language changes:**
+
+```go
+func (c *edgeContext) addEdgeQualified(src, dst, qualifiedDst, kind string) { ... }
+```
+
+| Language | Short name | Qualified name source |
+|---|---|---|
+| Java | `scoped_identifier.name` → `"List"` | `scoped_identifier` content → `"java.util.List"` |
+| Go | import path last component → `"fmt"` | full path string → `"fmt"` or `"github.com/foo/bar"` |
+| Python | `dotted_name` → `"os"` | same (Python imports are already module paths) |
+| TypeScript | `import_specifier.name` → `"foo"` | module path + name → `"@scope/pkg/foo"` |
+| Groovy | last dot component → `"List"` | `dotted_identifier` content → `"java.util.List"` |
+| Rust | `scoped_identifier.name` → `"HashMap"` | `scoped_identifier` content → `"std::collections::HashMap"` |
+
+**Storage — InsertEdges:**
+
+```go
+pendingStmt: INSERT INTO pending_edges
+    (src_symbol_id, dst_symbol_name, dst_qualified_name, kind)
+    VALUES (?, ?, ?, ?)
+```
+
+### 2.2 Add Language Filtering to Edge Resolution
+
+Add language awareness to `pending_edges` resolution and symbol lookup so a Java
+import never resolves to a Python symbol.
+
+**Option A — Store language on pending_edges (preferred):**
+
+```sql
+ALTER TABLE pending_edges ADD COLUMN src_language TEXT DEFAULT '';
+```
+
+Populated from the source file's language during `InsertEdges`. Then
+`ResolvePendingEdges` joins through `symbols → files` to ensure the destination
+symbol's language matches the source:
+
+```sql
+SELECT pe.id, pe.src_symbol_id, pe.dst_symbol_name, pe.kind, pe.src_language
+FROM pending_edges pe
+WHERE pe.dst_symbol_name IN (...)
+
+-- Resolution lookup becomes:
+SELECT s.id FROM symbols s
+JOIN files f ON s.file_id = f.id
+WHERE s.name = ? AND f.language = ?
+LIMIT 1
+```
+
+**Option B — Derive language from src_symbol_id at resolution time:**
+
+No schema change. `ResolvePendingEdges` joins `pending_edges → symbols → files`
+to get the source language, then filters destination candidates by the same
+language. More complex query but avoids adding a column.
+
+**Recommendation: Option A.** The extra column is cheap, makes queries simpler,
+and avoids a 3-table join during resolution. Both columns (`dst_qualified_name`
+and `src_language`) can be added in a single migration.
+
+**Combined migration (v2 → v3):**
+
+```sql
+ALTER TABLE pending_edges ADD COLUMN dst_qualified_name TEXT DEFAULT '';
+ALTER TABLE pending_edges ADD COLUMN src_language TEXT DEFAULT '';
+```
+
+### 2.3 Fix lookupSymbolIDTx
+
+Add a `language` parameter:
+
+```go
+func lookupSymbolIDTx(ctx context.Context, tx *sql.Tx, name string, fileID int64, language string) (int64, error) {
+    // Try same-file first (unchanged)
+    // ...
+    // Fallback: filter by language
+    if language != "" {
+        err := tx.QueryRowContext(ctx,
+            `SELECT s.id FROM symbols s JOIN files f ON s.file_id = f.id
+             WHERE s.name = ? AND f.language = ? LIMIT 1`,
+            name, language).Scan(&id)
+        if err == nil { return id, nil }
+    }
+    // Final fallback: any language (backward compat for non-import edges)
+    err := tx.QueryRowContext(ctx,
+        "SELECT id FROM symbols WHERE name = ? LIMIT 1", name).Scan(&id)
+    // ...
+}
+```
+
+Call sites pass the source file's language for import edges, empty string for
+call/inheritance edges (which are always within the same language anyway).
+
+---
+
+## 3. Files to Modify
+
+| File | Change |
+|---|---|
+| `internal/types/entities.go` | Add `DstQualifiedName` to `EdgeRecord` |
+| `internal/storage/schema.go` | Bump to v3, add migration for both new columns |
+| `internal/storage/graph.go` | Update `InsertEdges` to store qualified name + language; update `lookupSymbolIDTx` to accept language; update `ResolvePendingEdges` to filter by language |
+| `internal/parser/edges.go` | Add `addEdgeQualified` helper; update 6 language import handlers to extract full import path |
+| `internal/daemon/writer.go` | Pass file language to `InsertEdges` |
+| `internal/format/types.go` | Add `QualifiedName` to `SymbolRef` (if merged after `fix-symbol-missing`) |
+| `internal/mcp/tools.go` | Surface qualified name in responses (if merged after `fix-symbol-missing`) |
+
+---
+
+## 4. Migration Safety
+
+- Two `ALTER TABLE ADD COLUMN` with `DEFAULT` — safe in SQLite, no table rewrite.
+- Existing `pending_edges` rows get empty defaults for both columns.
+- Old pending edges without language info fall back to language-unfiltered lookup
+  (same behavior as today). Only newly indexed edges get the stricter resolution.
+- Re-indexing a project fully populates both columns for all pending edges.
+
+---
+
+## 5. Testing Plan
+
+| Test | Verifies |
+|---|---|
+| `TestEdges_JavaImportQualifiedName` | Java handler extracts `"List"` and `"java.util.List"` |
+| `TestEdges_GoImportQualifiedName` | Go handler extracts short + full module path |
+| `TestEdges_RustImportQualifiedName` | Rust handler extracts short + `"std::collections::HashMap"` |
+| `TestInsertEdges_QualifiedNameAndLanguageStored` | `pending_edges` row has correct `dst_qualified_name` and `src_language` |
+| `TestResolvePendingEdges_LanguageFilter` | Java pending edge does NOT resolve to a Python symbol with the same name |
+| `TestResolvePendingEdges_SameLanguageResolves` | Java pending edge resolves to a Java symbol correctly |
+| `TestLookupSymbolIDTx_LanguageFilter` | `lookupSymbolIDTx("Config", 0, "java")` returns Java symbol, not Python |
+| `TestIntegration_CrossLanguageNoMisresolution` | Polyglot project: Python `Config` class + Java `import Config` — Java edge stays pending, not resolved to Python |
+| `TestMigration_V2toV3` | Existing DB gains both columns, existing rows get empty defaults |
+
+---
+
+## 6. Scope
+
+**In scope:**
+- `dst_qualified_name` column and parser extraction for all 6 languages
+- `src_language` column and language-filtered resolution
+- `lookupSymbolIDTx` language parameter
+- Schema migration v2 → v3
+- Surfacing qualified name in query results
+
+**Out of scope:**
+- Adding qualified name to the resolved `edges` table (only `pending_edges`)
+- Using qualified name for smarter resolution (e.g. matching `java.util.List`
+  to a project class in `java.util` package) — qualified name is for display
+  disambiguation in this iteration, not for resolution logic
+- CLI `symbols` / `deps` commands (separate feature gap tracked elsewhere)
+
+---
+
+## 7. Code Coverage
+
+Enforce a minimum of **90% line coverage** on all changed/new code. Measure with:
+
+```bash
+go test -tags sqlite_fts5 -coverprofile=cover.out ./internal/parser/ ./internal/storage/ ./internal/daemon/ ./internal/mcp/
+go tool cover -func=cover.out | grep -E '(edges|graph|writer|schema|tools)\.go'
+```
+
+Coverage targets by file:
+
+| File | Minimum | Rationale |
+|---|---|---|
+| `internal/parser/edges.go` | 90% | All 6 language import handlers must be exercised with qualified name extraction |
+| `internal/storage/graph.go` | 90% | `InsertEdges`, `ResolvePendingEdges`, `lookupSymbolIDTx` — all paths including language-filtered and fallback |
+| `internal/daemon/writer.go` | 80% | Only the `InsertEdges` call site changes; rest of `processEnrichmentJob` is existing code |
+| `internal/storage/schema.go` | 90% | Migration path v2→v3 must be tested for both fresh and existing databases |
+
+Gaps to watch:
+- Each language handler must have at least one test that asserts `DstQualifiedName` is populated.
+- `lookupSymbolIDTx` needs tests for: same-file match, same-language match, cross-language rejection, and fallback-to-any.
+- `ResolvePendingEdges` needs tests for: same-language resolution, cross-language skip, and backward compat (empty `src_language` falls back to unfiltered).
+
+---
+
+## 8. Adversarial Analysis
+
+Run `/adversarial-analyst` on the final changeset before merge. The analysis
+must cover these specific attack surfaces:
+
+**Edge resolution correctness:**
+- Can a pending edge with `src_language=""` (pre-migration) resolve to a wrong-language symbol?
+- What happens when `ResolvePendingEdges` encounters a name that exists in 3 languages — does `LIMIT 1` with the language filter always pick the right one, or can file ordering cause nondeterminism within the same language?
+- If a file is re-indexed and its language field changes (e.g. `.tsx` reclassified), do stale pending edges with the old language get cleaned up?
+
+**Qualified name extraction:**
+- Are there tree-sitter AST shapes where the qualified name extraction returns partial paths? (e.g. Java star imports `import java.util.*`, Python `from os.path import *`, Rust `use std::*`)
+- What happens with aliased imports? (Java: none. Go: `import alias "pkg"`. Python: `import X as Y`. Rust: `use Foo as Bar`. TS: `import { X as Y }`.) Does the qualified name reflect the original or the alias?
+- What happens with re-exports? (TS: `export { X } from './other'`)
+
+**Migration and data integrity:**
+- Can the v2→v3 migration run concurrently with the daemon reading pending_edges?
+- After migration, if the daemon crashes mid-index, are partially-written pending edges (with qualified name) and old pending edges (without) mixed in the table? Does this cause query issues?
+
+**Performance at scale:**
+- `ResolvePendingEdges` now joins `symbols → files` for language filtering. In a monorepo with 100k+ symbols, does this degrade? Is an index needed on `files(language)`?
+- The qualified name column increases row size. For 120k pending_edges, what is the storage impact?
+
+**Failure mode classification:**
+- Which failures are loud (error returned) vs silent (wrong data stored)?
+- What is the blast radius of a misresolved edge — does it cascade to other queries or is it contained?

--- a/internal/core/assembler_test.go
+++ b/internal/core/assembler_test.go
@@ -139,7 +139,7 @@ func TestAssemble_StructuralExpansion(t *testing.T) {
 		}
 		return store.InsertEdges(ctx, tx, fileID, []types.EdgeRecord{
 			{SrcSymbolName: "Caller", DstSymbolName: "Helper", Kind: "calls"},
-		}, symMap)
+		}, symMap, "")
 	})
 	if err != nil {
 		t.Fatalf("InsertEdges: %v", err)
@@ -258,7 +258,7 @@ func TestStructuralExpand_WithEdges(t *testing.T) {
 		}
 		return store.InsertEdges(ctx, tx, fileID1, []types.EdgeRecord{
 			{SrcSymbolName: "Main", DstSymbolName: "Serve", Kind: "calls"},
-		}, symMap)
+		}, symMap, "")
 	})
 	if err != nil {
 		t.Fatalf("InsertEdges: %v", err)

--- a/internal/core/ranker_test.go
+++ b/internal/core/ranker_test.go
@@ -381,7 +381,7 @@ func TestComputeStructuralScores_WithGraphEdges(t *testing.T) {
 		}
 		return store.InsertEdges(ctx, tx, fileID1, []types.EdgeRecord{
 			{SrcSymbolName: "FuncA", DstSymbolName: "FuncB", Kind: "calls"},
-		}, symMap)
+		}, symMap, "")
 	})
 	if err != nil {
 		t.Fatalf("InsertEdges: %v", err)

--- a/internal/daemon/writer.go
+++ b/internal/daemon/writer.go
@@ -380,7 +380,7 @@ func processEnrichmentJob(ctx context.Context, tx *sql.Tx, store *storage.Store,
 	if err := store.DeleteEdgesByFile(ctx, tx, fileID); err != nil {
 		return nil, fmt.Errorf("delete old edges for %s: %w", job.FilePath, err)
 	}
-	if err := store.InsertEdges(ctx, tx, fileID, job.Edges, symbolIDs); err != nil {
+	if err := store.InsertEdges(ctx, tx, fileID, job.Edges, symbolIDs, job.File.Language); err != nil {
 		return nil, fmt.Errorf("insert edges for %s: %w", job.FilePath, err)
 	}
 

--- a/internal/format/types.go
+++ b/internal/format/types.go
@@ -12,11 +12,12 @@ type SymbolResult struct {
 
 // SymbolRef describes a symbol that references an unresolved name (e.g. an import of an external type).
 type SymbolRef struct {
-	Symbol   string `json:"symbol"`
-	Kind     string `json:"kind"`
-	FilePath string `json:"file_path"`
-	Line     int    `json:"line"`
-	Via      string `json:"via"`
+	Symbol        string `json:"symbol"`
+	Kind          string `json:"kind"`
+	FilePath      string `json:"file_path"`
+	Line          int    `json:"line"`
+	Via           string `json:"via"`
+	QualifiedName string `json:"qualified_name,omitempty"`
 }
 
 // SymbolsWithRefs is the enriched response when no definitions are found

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -250,11 +250,12 @@ func symbolsHandler(store *storage.Store) handlerFunc {
 					}
 					path, _ := store.GetFilePathByID(ctx, sym.FileID)
 					refs = append(refs, format.SymbolRef{
-						Symbol:   sym.Name,
-						Kind:     sym.Kind,
-						FilePath: path,
-						Line:     sym.Line,
-						Via:      c.Kind,
+						Symbol:        sym.Name,
+						Kind:          sym.Kind,
+						FilePath:      path,
+						Line:          sym.Line,
+						Via:           c.Kind,
+						QualifiedName: c.DstQualifiedName,
 					})
 				}
 				if len(refs) > 0 {

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -438,7 +438,7 @@ func setupDependenciesHandler(t *testing.T) handlerFunc {
 		}, map[string]int64{
 			"NewServer":     srcID,
 			"handleRequest": dstID,
-		})
+		}, "")
 	})
 	if err != nil {
 		t.Fatalf("InsertEdges: %v", err)
@@ -1229,7 +1229,7 @@ func setupHandlersWithPendingEdge(t *testing.T) (*storage.Store, handlerFunc, ha
 			{SrcSymbolName: "NewServer", DstSymbolName: "ExternalLib", Kind: "imports"},
 		}, map[string]int64{
 			"NewServer": srcID,
-		})
+		}, "")
 	})
 	if err != nil {
 		t.Fatalf("InsertEdges: %v", err)

--- a/internal/parser/edges.go
+++ b/internal/parser/edges.go
@@ -18,6 +18,10 @@ type edgeContext struct {
 }
 
 func (c *edgeContext) addEdge(src, dst, kind string) {
+	c.addEdgeQualified(src, dst, "", kind)
+}
+
+func (c *edgeContext) addEdgeQualified(src, dst, qualifiedDst, kind string) {
 	if dst == "" {
 		return
 	}
@@ -27,10 +31,11 @@ func (c *edgeContext) addEdge(src, dst, kind string) {
 	}
 	c.seen[key] = true
 	c.edges = append(c.edges, types.EdgeRecord{
-		SrcSymbolName: src,
-		DstSymbolName: dst,
-		Kind:          kind,
-		IsCrossFile:   kind == "imports",
+		SrcSymbolName:    src,
+		DstSymbolName:    dst,
+		DstQualifiedName: qualifiedDst,
+		Kind:             kind,
+		IsCrossFile:      kind == "imports",
 	})
 }
 
@@ -183,12 +188,21 @@ func (p *Parser) tsImportEdges(node *sitter.Node, owner string, ctx *edgeContext
 	if clause == nil {
 		return
 	}
+
+	// Extract module path from the import source (e.g. 'bar' in `import { Foo } from 'bar'`)
+	modulePath := ""
+	src := findChildByType(node, "string")
+	if src != nil {
+		modulePath = strings.Trim(src.Content(ctx.source), "\"'`")
+	}
+
 	for i := 0; i < int(clause.NamedChildCount()); i++ {
 		child := clause.NamedChild(i)
 		switch child.Type() {
 		case "identifier":
 			// Default import: import Foo from 'bar'
-			ctx.addEdge(owner, child.Content(ctx.source), "imports")
+			shortName := child.Content(ctx.source)
+			ctx.addEdgeQualified(owner, shortName, modulePath+"/"+shortName, "imports")
 		case "named_imports":
 			// Named imports: import { Foo, Bar } from 'baz'
 			for j := 0; j < int(child.NamedChildCount()); j++ {
@@ -196,7 +210,8 @@ func (p *Parser) tsImportEdges(node *sitter.Node, owner string, ctx *edgeContext
 				if spec.Type() == "import_specifier" {
 					name := spec.ChildByFieldName("name")
 					if name != nil {
-						ctx.addEdge(owner, name.Content(ctx.source), "imports")
+						shortName := name.Content(ctx.source)
+						ctx.addEdgeQualified(owner, shortName, modulePath+"/"+shortName, "imports")
 					}
 				}
 			}
@@ -204,7 +219,7 @@ func (p *Parser) tsImportEdges(node *sitter.Node, owner string, ctx *edgeContext
 			// import * as ns from 'bar'
 			name := extractName(child, ctx.source)
 			if name != "" {
-				ctx.addEdge(owner, name, "imports")
+				ctx.addEdgeQualified(owner, name, modulePath, "imports")
 			}
 		}
 	}
@@ -212,6 +227,12 @@ func (p *Parser) tsImportEdges(node *sitter.Node, owner string, ctx *edgeContext
 
 func (p *Parser) pyImportEdges(node *sitter.Node, owner string, ctx *edgeContext) {
 	moduleField := node.ChildByFieldName("module_name")
+
+	// Extract module prefix for "from X import Y" statements
+	modulePrefix := ""
+	if moduleField != nil {
+		modulePrefix = moduleField.Content(ctx.source)
+	}
 
 	var walk func(n *sitter.Node)
 	walk = func(n *sitter.Node) {
@@ -221,12 +242,22 @@ func (p *Parser) pyImportEdges(node *sitter.Node, owner string, ctx *edgeContext
 		}
 		switch n.Type() {
 		case "dotted_name":
-			ctx.addEdge(owner, n.Content(ctx.source), "imports")
+			content := n.Content(ctx.source)
+			qualified := content
+			if modulePrefix != "" {
+				qualified = modulePrefix + "." + content
+			}
+			ctx.addEdgeQualified(owner, content, qualified, "imports")
 			return
 		case "aliased_import":
 			name := n.ChildByFieldName("name")
 			if name != nil {
-				ctx.addEdge(owner, name.Content(ctx.source), "imports")
+				content := name.Content(ctx.source)
+				qualified := content
+				if modulePrefix != "" {
+					qualified = modulePrefix + "." + content
+				}
+				ctx.addEdgeQualified(owner, content, qualified, "imports")
 			}
 			return
 		case "wildcard_import":
@@ -248,7 +279,7 @@ func (p *Parser) goImportEdges(node *sitter.Node, owner string, ctx *edgeContext
 				pkgPath := strings.Trim(path.Content(ctx.source), "\"")
 				parts := strings.Split(pkgPath, "/")
 				pkgName := parts[len(parts)-1]
-				ctx.addEdge(owner, pkgName, "imports")
+				ctx.addEdgeQualified(owner, pkgName, pkgPath, "imports")
 			}
 			return
 		}
@@ -260,18 +291,20 @@ func (p *Parser) goImportEdges(node *sitter.Node, owner string, ctx *edgeContext
 }
 
 func (p *Parser) javaImportEdges(node *sitter.Node, owner string, ctx *edgeContext) {
-	// Java: import foo.bar.Baz; → extract "Baz"
+	// Java: import foo.bar.Baz; → extract "Baz" with qualified "foo.bar.Baz"
 	var walk func(n *sitter.Node)
 	walk = func(n *sitter.Node) {
 		if n.Type() == "scoped_identifier" {
+			qualified := n.Content(ctx.source)
 			name := n.ChildByFieldName("name")
 			if name != nil {
-				ctx.addEdge(owner, name.Content(ctx.source), "imports")
+				ctx.addEdgeQualified(owner, name.Content(ctx.source), qualified, "imports")
 			}
 			return
 		}
 		if n.Type() == "identifier" {
-			ctx.addEdge(owner, n.Content(ctx.source), "imports")
+			content := n.Content(ctx.source)
+			ctx.addEdgeQualified(owner, content, content, "imports")
 			return
 		}
 		for i := 0; i < int(n.NamedChildCount()); i++ {
@@ -282,13 +315,25 @@ func (p *Parser) javaImportEdges(node *sitter.Node, owner string, ctx *edgeConte
 }
 
 func (p *Parser) groovyImportEdges(node *sitter.Node, owner string, ctx *edgeContext) {
-	// Groovy: import foo.bar.Baz → extract last dot-separated component
+	// Groovy: import foo.bar.Baz → extract last dot-separated component with full qualified path
+	// Extract the full import text from the node to use as qualified name
+	fullImportText := node.Content(ctx.source)
+	// Strip "import " prefix and any trailing whitespace/semicolons
+	fullImportText = strings.TrimPrefix(fullImportText, "import ")
+	fullImportText = strings.TrimRight(fullImportText, " \t\n\r;")
+
 	var walk func(n *sitter.Node)
 	walk = func(n *sitter.Node) {
 		if n.Type() == "dotted_identifier" || n.Type() == "identifier" {
 			content := n.Content(ctx.source)
 			parts := strings.Split(content, ".")
-			ctx.addEdge(owner, parts[len(parts)-1], "imports")
+			shortName := parts[len(parts)-1]
+			// Use fullImportText as qualified name if it contains dots (the full path)
+			qualified := content
+			if strings.Contains(fullImportText, ".") {
+				qualified = fullImportText
+			}
+			ctx.addEdgeQualified(owner, shortName, qualified, "imports")
 			return
 		}
 		for i := 0; i < int(n.NamedChildCount()); i++ {
@@ -299,30 +344,61 @@ func (p *Parser) groovyImportEdges(node *sitter.Node, owner string, ctx *edgeCon
 }
 
 func (p *Parser) rustImportEdges(node *sitter.Node, owner string, ctx *edgeContext) {
-	// Rust: use std::collections::HashMap; → extract "HashMap"
+	// Rust: use std::collections::HashMap; → extract "HashMap" with qualified "std::collections::HashMap"
 	// Also handles: use std::{io, fs}; (use_list) and use foo as bar (use_as_clause)
 	var walk func(n *sitter.Node)
 	walk = func(n *sitter.Node) {
 		switch n.Type() {
 		case "use_as_clause":
-			// use foo::Bar as Baz → extract the alias "Baz"
+			// use foo::Bar as Baz → extract the alias "Baz" with the original path as qualified
 			alias := n.ChildByFieldName("alias")
 			if alias != nil {
-				ctx.addEdge(owner, alias.Content(ctx.source), "imports")
+				// Extract the path part (before "as")
+				path := n.ChildByFieldName("path")
+				qualified := ""
+				if path != nil {
+					qualified = path.Content(ctx.source)
+				}
+				ctx.addEdgeQualified(owner, alias.Content(ctx.source), qualified, "imports")
 				return
 			}
 			// No alias field, fall through to extract the path's last component
 		case "scoped_identifier":
+			qualified := n.Content(ctx.source)
 			name := n.ChildByFieldName("name")
 			if name != nil {
-				ctx.addEdge(owner, name.Content(ctx.source), "imports")
+				ctx.addEdgeQualified(owner, name.Content(ctx.source), qualified, "imports")
 			}
 			return
 		case "identifier":
-			ctx.addEdge(owner, n.Content(ctx.source), "imports")
+			content := n.Content(ctx.source)
+			ctx.addEdgeQualified(owner, content, content, "imports")
 			return
 		case "scoped_use_list":
 			// use std::{io, fs}; → recurse into the use_list child
+			// Extract the prefix path for qualification
+			pathNode := n.ChildByFieldName("path")
+			prefix := ""
+			if pathNode != nil {
+				prefix = pathNode.Content(ctx.source)
+			}
+			list := n.ChildByFieldName("list")
+			if list != nil {
+				for i := 0; i < int(list.NamedChildCount()); i++ {
+					child := list.NamedChild(i)
+					if child.Type() == "identifier" {
+						shortName := child.Content(ctx.source)
+						qualified := shortName
+						if prefix != "" {
+							qualified = prefix + "::" + shortName
+						}
+						ctx.addEdgeQualified(owner, shortName, qualified, "imports")
+					} else {
+						walk(child)
+					}
+				}
+			}
+			return
 		case "use_wildcard":
 			// use foo::*; → skip, no specific name to extract
 			return

--- a/internal/parser/edges_test.go
+++ b/internal/parser/edges_test.go
@@ -632,3 +632,270 @@ func (m *MyType) String() string { return "" }
 	}
 	t.Error("expected import edge for 'fmt'")
 }
+
+// ── Qualified name extraction tests ──
+
+func TestEdges_JavaImportQualifiedName(t *testing.T) {
+	t.Parallel()
+
+	p, err := NewParser()
+	if err != nil {
+		t.Fatalf("NewParser: %v", err)
+	}
+	defer p.Close()
+
+	src := []byte(`package com.example;
+
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+
+public class MyService {
+    public void run() {}
+}
+`)
+
+	result, err := p.Parse(context.Background(), ParseInput{
+		FilePath: "MyService.java",
+		Content:  src,
+		Language: "java",
+	})
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	expected := map[string]string{
+		"List":            "java.util.List",
+		"ExecutorService": "java.util.concurrent.ExecutorService",
+	}
+	for _, e := range result.Edges {
+		if e.Kind == "imports" {
+			if want, ok := expected[e.DstSymbolName]; ok {
+				if e.DstQualifiedName != want {
+					t.Errorf("import %q: DstQualifiedName=%q, want %q", e.DstSymbolName, e.DstQualifiedName, want)
+				}
+				delete(expected, e.DstSymbolName)
+			}
+		}
+	}
+	for name := range expected {
+		t.Errorf("missing import edge for %q", name)
+	}
+}
+
+func TestEdges_GoImportQualifiedName(t *testing.T) {
+	t.Parallel()
+
+	p, err := NewParser()
+	if err != nil {
+		t.Fatalf("NewParser: %v", err)
+	}
+	defer p.Close()
+
+	src := []byte(`package main
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func main() {
+	fmt.Println("hello")
+	http.ListenAndServe(":8080", nil)
+}
+`)
+
+	result, err := p.Parse(context.Background(), ParseInput{
+		FilePath: "main.go",
+		Content:  src,
+		Language: "go",
+	})
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	expected := map[string]string{
+		"fmt":  "fmt",
+		"http": "net/http",
+	}
+	for _, e := range result.Edges {
+		if e.Kind == "imports" {
+			if want, ok := expected[e.DstSymbolName]; ok {
+				if e.DstQualifiedName != want {
+					t.Errorf("import %q: DstQualifiedName=%q, want %q", e.DstSymbolName, e.DstQualifiedName, want)
+				}
+				delete(expected, e.DstSymbolName)
+			}
+		}
+	}
+	for name := range expected {
+		t.Errorf("missing import edge for %q", name)
+	}
+}
+
+func TestEdges_RustImportQualifiedName(t *testing.T) {
+	t.Parallel()
+
+	p, err := NewParser()
+	if err != nil {
+		t.Fatalf("NewParser: %v", err)
+	}
+	defer p.Close()
+
+	src := []byte(`use std::collections::HashMap;
+use std::io;
+
+fn main() {}
+`)
+
+	result, err := p.Parse(context.Background(), ParseInput{
+		FilePath: "main.rs",
+		Content:  src,
+		Language: "rust",
+	})
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	expected := map[string]string{
+		"HashMap": "std::collections::HashMap",
+		"io":      "std::io",
+	}
+	for _, e := range result.Edges {
+		if e.Kind == "imports" {
+			if want, ok := expected[e.DstSymbolName]; ok {
+				if e.DstQualifiedName != want {
+					t.Errorf("import %q: DstQualifiedName=%q, want %q", e.DstSymbolName, e.DstQualifiedName, want)
+				}
+				delete(expected, e.DstSymbolName)
+			}
+		}
+	}
+	for name := range expected {
+		t.Errorf("missing import edge for %q", name)
+	}
+}
+
+func TestEdges_TypeScriptImportQualifiedName(t *testing.T) {
+	t.Parallel()
+
+	p, err := NewParser()
+	if err != nil {
+		t.Fatalf("NewParser: %v", err)
+	}
+	defer p.Close()
+
+	src := []byte(`import { foo } from '@scope/pkg';
+
+export function doStuff(): string {
+  return foo();
+}`)
+
+	result, err := p.Parse(context.Background(), ParseInput{
+		FilePath: "test.ts",
+		Content:  src,
+		Language: "typescript",
+	})
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	for _, e := range result.Edges {
+		if e.Kind == "imports" && e.DstSymbolName == "foo" {
+			if e.DstQualifiedName != "@scope/pkg/foo" {
+				t.Errorf("import 'foo': DstQualifiedName=%q, want %q", e.DstQualifiedName, "@scope/pkg/foo")
+			}
+			return
+		}
+	}
+	t.Error("expected import edge for 'foo'")
+}
+
+func TestEdges_PythonImportQualifiedName(t *testing.T) {
+	t.Parallel()
+
+	p, err := NewParser()
+	if err != nil {
+		t.Fatalf("NewParser: %v", err)
+	}
+	defer p.Close()
+
+	src := []byte(`from os.path import join
+import json
+
+def process():
+    pass
+`)
+
+	result, err := p.Parse(context.Background(), ParseInput{
+		FilePath: "test.py",
+		Content:  src,
+		Language: "python",
+	})
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	expected := map[string]string{
+		"join": "os.path.join",
+		"json": "json",
+	}
+	for _, e := range result.Edges {
+		if e.Kind == "imports" {
+			if want, ok := expected[e.DstSymbolName]; ok {
+				if e.DstQualifiedName != want {
+					t.Errorf("import %q: DstQualifiedName=%q, want %q", e.DstSymbolName, e.DstQualifiedName, want)
+				}
+				delete(expected, e.DstSymbolName)
+			}
+		}
+	}
+	for name := range expected {
+		t.Errorf("missing import edge for %q", name)
+	}
+}
+
+func TestEdges_GroovyImportQualifiedName(t *testing.T) {
+	t.Parallel()
+
+	p, err := NewParser()
+	if err != nil {
+		t.Fatalf("NewParser: %v", err)
+	}
+	defer p.Close()
+
+	src := []byte(`import groovy.transform.ToString
+import java.util.List
+
+class MyService {
+    String name
+    List items
+}
+`)
+
+	result, err := p.Parse(context.Background(), ParseInput{
+		FilePath: "test.groovy",
+		Content:  src,
+		Language: "groovy",
+	})
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	expected := map[string]string{
+		"ToString": "groovy.transform.ToString",
+		"List":     "java.util.List",
+	}
+	for _, e := range result.Edges {
+		if e.Kind == "imports" {
+			if want, ok := expected[e.DstSymbolName]; ok {
+				if e.DstQualifiedName != want {
+					t.Errorf("import %q: DstQualifiedName=%q, want %q", e.DstSymbolName, e.DstQualifiedName, want)
+				}
+				delete(expected, e.DstSymbolName)
+			}
+		}
+	}
+	for name := range expected {
+		t.Errorf("missing import edge for %q", name)
+	}
+}

--- a/internal/storage/graph.go
+++ b/internal/storage/graph.go
@@ -12,7 +12,9 @@ import (
 // InsertEdges inserts resolved edges into the edges table and queues
 // unresolved edges into pending_edges. symbolIDs maps symbol names to their
 // database IDs from the current file. Uses tx to see uncommitted symbols.
-func (s *Store) InsertEdges(ctx context.Context, tx *sql.Tx, fileID int64, edges []types.EdgeRecord, symbolIDs map[string]int64) error {
+// language is the source file's language, used for language-filtered lookup
+// and stored on pending_edges for cross-language misresolution prevention.
+func (s *Store) InsertEdges(ctx context.Context, tx *sql.Tx, fileID int64, edges []types.EdgeRecord, symbolIDs map[string]int64, language string) error {
 	if len(edges) == 0 {
 		return nil
 	}
@@ -26,8 +28,8 @@ func (s *Store) InsertEdges(ctx context.Context, tx *sql.Tx, fileID int64, edges
 	defer edgeStmt.Close()
 
 	pendingStmt, err := tx.PrepareContext(ctx, `
-		INSERT INTO pending_edges (src_symbol_id, dst_symbol_name, kind)
-		VALUES (?, ?, ?)`)
+		INSERT INTO pending_edges (src_symbol_id, dst_symbol_name, dst_qualified_name, kind, src_language)
+		VALUES (?, ?, ?, ?, ?)`)
 	if err != nil {
 		return fmt.Errorf("prepare pending edge insert: %w", err)
 	}
@@ -41,8 +43,8 @@ func (s *Store) InsertEdges(ctx context.Context, tx *sql.Tx, fileID int64, edges
 
 		dstID := symbolIDs[e.DstSymbolName]
 		if dstID == 0 {
-			// Lookup via tx, preferring same-file symbols
-			dstID, _ = lookupSymbolIDTx(ctx, tx, e.DstSymbolName, fileID)
+			// Lookup via tx, preferring same-file, then same-language
+			dstID, _ = lookupSymbolIDTx(ctx, tx, e.DstSymbolName, fileID, language)
 		}
 
 		if dstID != 0 {
@@ -50,7 +52,7 @@ func (s *Store) InsertEdges(ctx context.Context, tx *sql.Tx, fileID int64, edges
 				return fmt.Errorf("insert edge %s→%s: %w", e.SrcSymbolName, e.DstSymbolName, err)
 			}
 		} else {
-			if _, err := pendingStmt.ExecContext(ctx, srcID, e.DstSymbolName, e.Kind); err != nil {
+			if _, err := pendingStmt.ExecContext(ctx, srcID, e.DstSymbolName, e.DstQualifiedName, e.Kind, language); err != nil {
 				return fmt.Errorf("insert pending edge %s→%s: %w", e.SrcSymbolName, e.DstSymbolName, err)
 			}
 		}
@@ -60,7 +62,8 @@ func (s *Store) InsertEdges(ctx context.Context, tx *sql.Tx, fileID int64, edges
 }
 
 // ResolvePendingEdges attempts to resolve pending edges whose dst_symbol_name
-// matches any of the given newly-inserted symbol names.
+// matches any of the given newly-inserted symbol names. Uses src_language
+// to ensure a Java import never resolves to a Python symbol.
 func (s *Store) ResolvePendingEdges(ctx context.Context, tx *sql.Tx, newSymbolNames []string) error {
 	if len(newSymbolNames) == 0 {
 		return nil
@@ -74,7 +77,7 @@ func (s *Store) ResolvePendingEdges(ctx context.Context, tx *sql.Tx, newSymbolNa
 	}
 
 	query := fmt.Sprintf(`
-		SELECT id, src_symbol_id, dst_symbol_name, kind
+		SELECT id, src_symbol_id, dst_symbol_name, kind, src_language
 		FROM pending_edges
 		WHERE dst_symbol_name IN (%s)`, strings.Join(placeholders, ","))
 
@@ -85,16 +88,17 @@ func (s *Store) ResolvePendingEdges(ctx context.Context, tx *sql.Tx, newSymbolNa
 	defer rows.Close()
 
 	type pending struct {
-		id      int64
-		srcID   int64
-		dstName string
-		kind    string
+		id       int64
+		srcID    int64
+		dstName  string
+		kind     string
+		language string
 	}
 	var toResolve []pending
 
 	for rows.Next() {
 		var p pending
-		if err := rows.Scan(&p.id, &p.srcID, &p.dstName, &p.kind); err != nil {
+		if err := rows.Scan(&p.id, &p.srcID, &p.dstName, &p.kind, &p.language); err != nil {
 			return fmt.Errorf("scan pending edge: %w", err)
 		}
 		toResolve = append(toResolve, p)
@@ -122,7 +126,7 @@ func (s *Store) ResolvePendingEdges(ctx context.Context, tx *sql.Tx, newSymbolNa
 	defer delStmt.Close()
 
 	for _, p := range toResolve {
-		dstID, err := lookupSymbolIDTx(ctx, tx, p.dstName, 0)
+		dstID, err := lookupSymbolIDTx(ctx, tx, p.dstName, 0, p.language)
 		if err != nil || dstID == 0 {
 			continue
 		}
@@ -241,16 +245,17 @@ func (s *Store) PendingEdgeCallers(ctx context.Context, dstName string) ([]int64
 
 // PendingEdgeCaller holds a source symbol ID and the edge kind from a pending edge.
 type PendingEdgeCaller struct {
-	SrcSymbolID int64
-	Kind        string
+	SrcSymbolID      int64
+	Kind             string
+	DstQualifiedName string
 }
 
-// PendingEdgeCallersWithKind returns src_symbol_id and kind from pending_edges
-// for a given unresolved destination name. Used by the symbols handler to show
-// which symbols reference an external type.
+// PendingEdgeCallersWithKind returns src_symbol_id, kind, and dst_qualified_name
+// from pending_edges for a given unresolved destination name. Used by the symbols
+// handler to show which symbols reference an external type.
 func (s *Store) PendingEdgeCallersWithKind(ctx context.Context, dstName string) ([]PendingEdgeCaller, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT DISTINCT src_symbol_id, kind
+		SELECT DISTINCT src_symbol_id, kind, dst_qualified_name
 		FROM pending_edges
 		WHERE dst_symbol_name = ?`, dstName)
 	if err != nil {
@@ -261,7 +266,7 @@ func (s *Store) PendingEdgeCallersWithKind(ctx context.Context, dstName string) 
 	var results []PendingEdgeCaller
 	for rows.Next() {
 		var c PendingEdgeCaller
-		if err := rows.Scan(&c.SrcSymbolID, &c.Kind); err != nil {
+		if err := rows.Scan(&c.SrcSymbolID, &c.Kind, &c.DstQualifiedName); err != nil {
 			return nil, fmt.Errorf("scan pending caller with kind: %w", err)
 		}
 		results = append(results, c)
@@ -279,8 +284,10 @@ func (s *Store) DeleteEdgesByFile(ctx context.Context, tx *sql.Tx, fileID int64)
 
 // lookupSymbolIDTx looks up a symbol by name within a write transaction,
 // ensuring uncommitted symbols from the current transaction are visible.
-// Prefers a same-file match (fileID) before falling back to global lookup.
-func lookupSymbolIDTx(ctx context.Context, tx *sql.Tx, name string, fileID int64) (int64, error) {
+// Prefers same-file match, then same-language match, then global fallback.
+// Pass language="" for non-import edges (calls, inherits) where cross-language
+// is not a concern.
+func lookupSymbolIDTx(ctx context.Context, tx *sql.Tx, name string, fileID int64, language string) (int64, error) {
 	var id int64
 	// Try same-file first
 	if fileID > 0 {
@@ -291,7 +298,25 @@ func lookupSymbolIDTx(ctx context.Context, tx *sql.Tx, name string, fileID int64
 			return id, nil
 		}
 	}
-	// Fallback to global
+	// Try same-language match
+	if language != "" {
+		err := tx.QueryRowContext(ctx,
+			`SELECT s.id FROM symbols s JOIN files f ON s.file_id = f.id
+			 WHERE s.name = ? AND f.language = ? LIMIT 1`,
+			name, language).Scan(&id)
+		if err == nil {
+			return id, nil
+		}
+		// When a language is specified, do NOT fall back to global lookup.
+		// This prevents cross-language misresolution (e.g. Java import
+		// resolving to a Python symbol).
+		if err == sql.ErrNoRows {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("lookup symbol %s (lang=%s): %w", name, language, err)
+	}
+	// Global fallback: no language constraint (for non-import edges
+	// and pre-migration pending edges with empty src_language)
 	err := tx.QueryRowContext(ctx, "SELECT id FROM symbols WHERE name = ? LIMIT 1", name).Scan(&id)
 	if err == sql.ErrNoRows {
 		return 0, nil

--- a/internal/storage/graph_test.go
+++ b/internal/storage/graph_test.go
@@ -27,11 +27,18 @@ func setupTestDB(t *testing.T) (*DB, *Store) {
 // insertTestFileChunkSymbol creates a file, chunk, and symbol in one shot.
 // Returns fileID, chunkID, symbolID.
 func insertTestFileChunkSymbol(t *testing.T, store *Store, path, symbolName string) (int64, int64, int64) {
+	return insertTestFileChunkSymbolWithLang(t, store, path, symbolName, "")
+}
+
+// insertTestFileChunkSymbolWithLang creates a file with a specific language, chunk, and symbol.
+// Returns fileID, chunkID, symbolID.
+func insertTestFileChunkSymbolWithLang(t *testing.T, store *Store, path, symbolName, language string) (int64, int64, int64) {
 	t.Helper()
 	ctx := context.Background()
 
 	fileID, err := store.UpsertFile(ctx, &types.FileRecord{
 		Path: path, ContentHash: "h_" + path, Mtime: 1.0,
+		Language:        language,
 		EmbeddingStatus: "pending", ParseQuality: "full",
 	})
 	if err != nil {
@@ -74,7 +81,7 @@ func TestInsertEdges_Resolved(t *testing.T) {
 	}
 
 	err := db.WithWriteTx(func(tx *sql.Tx) error {
-		return store.InsertEdges(ctx, tx, fileID, edges, symbolIDs)
+		return store.InsertEdges(ctx, tx, fileID, edges, symbolIDs, "")
 	})
 	if err != nil {
 		t.Fatalf("InsertEdges: %v", err)
@@ -109,7 +116,7 @@ func TestInsertEdges_Pending(t *testing.T) {
 	}
 
 	err := db.WithWriteTx(func(tx *sql.Tx) error {
-		return store.InsertEdges(ctx, tx, fileID, edges, symbolIDs)
+		return store.InsertEdges(ctx, tx, fileID, edges, symbolIDs, "")
 	})
 	if err != nil {
 		t.Fatalf("InsertEdges: %v", err)
@@ -151,7 +158,7 @@ func TestResolvePendingEdges(t *testing.T) {
 	}
 
 	err := db.WithWriteTx(func(tx *sql.Tx) error {
-		return store.InsertEdges(ctx, tx, fileID, edges, symbolIDs)
+		return store.InsertEdges(ctx, tx, fileID, edges, symbolIDs, "")
 	})
 	if err != nil {
 		t.Fatalf("InsertEdges: %v", err)
@@ -205,7 +212,7 @@ func TestNeighbors_Outgoing(t *testing.T) {
 	err := db.WithWriteTx(func(tx *sql.Tx) error {
 		return store.InsertEdges(ctx, tx, fileID, []types.EdgeRecord{
 			{SrcSymbolName: "FuncA", DstSymbolName: "FuncB", Kind: "calls"},
-		}, map[string]int64{"FuncA": symAID, "FuncB": symBID})
+		}, map[string]int64{"FuncA": symAID, "FuncB": symBID}, "")
 	})
 	if err != nil {
 		t.Fatalf("InsertEdges A->B: %v", err)
@@ -221,7 +228,7 @@ func TestNeighbors_Outgoing(t *testing.T) {
 	err = db.WithWriteTx(func(tx *sql.Tx) error {
 		return store.InsertEdges(ctx, tx, bFileID, []types.EdgeRecord{
 			{SrcSymbolName: "FuncB", DstSymbolName: "FuncC", Kind: "calls"},
-		}, map[string]int64{"FuncB": symBID, "FuncC": symCID})
+		}, map[string]int64{"FuncB": symBID, "FuncC": symCID}, "")
 	})
 	if err != nil {
 		t.Fatalf("InsertEdges B->C: %v", err)
@@ -261,7 +268,7 @@ func TestNeighbors_Incoming(t *testing.T) {
 	err := db.WithWriteTx(func(tx *sql.Tx) error {
 		return store.InsertEdges(ctx, tx, fileID, []types.EdgeRecord{
 			{SrcSymbolName: "FuncA", DstSymbolName: "FuncB", Kind: "calls"},
-		}, map[string]int64{"FuncA": symAID, "FuncB": symBID})
+		}, map[string]int64{"FuncA": symAID, "FuncB": symBID}, "")
 	})
 	if err != nil {
 		t.Fatalf("InsertEdges A->B: %v", err)
@@ -277,7 +284,7 @@ func TestNeighbors_Incoming(t *testing.T) {
 	err = db.WithWriteTx(func(tx *sql.Tx) error {
 		return store.InsertEdges(ctx, tx, bFileID, []types.EdgeRecord{
 			{SrcSymbolName: "FuncB", DstSymbolName: "FuncC", Kind: "calls"},
-		}, map[string]int64{"FuncB": symBID, "FuncC": symCID})
+		}, map[string]int64{"FuncB": symBID, "FuncC": symCID}, "")
 	})
 	if err != nil {
 		t.Fatalf("InsertEdges B->C: %v", err)
@@ -316,12 +323,12 @@ func TestDeleteEdgesByFile_RemovesTargetEdges(t *testing.T) {
 	if err := db.WithWriteTx(func(tx *sql.Tx) error {
 		if err := store.InsertEdges(ctx, tx, fileIDA, []types.EdgeRecord{
 			{SrcSymbolName: "FuncA", DstSymbolName: "FuncB", Kind: "calls"},
-		}, map[string]int64{"FuncA": symIDA, "FuncB": symIDB}); err != nil {
+		}, map[string]int64{"FuncA": symIDA, "FuncB": symIDB}, ""); err != nil {
 			return err
 		}
 		return store.InsertEdges(ctx, tx, fileIDC, []types.EdgeRecord{
 			{SrcSymbolName: "FuncC", DstSymbolName: "FuncB", Kind: "calls"},
-		}, map[string]int64{"FuncC": symIDC, "FuncB": symIDB})
+		}, map[string]int64{"FuncC": symIDC, "FuncB": symIDB}, "")
 	}); err != nil {
 		t.Fatalf("InsertEdges: %v", err)
 	}
@@ -365,12 +372,12 @@ func TestNeighbors_Both(t *testing.T) {
 	if err := db.WithWriteTx(func(tx *sql.Tx) error {
 		if err := store.InsertEdges(ctx, tx, fileIDA, []types.EdgeRecord{
 			{SrcSymbolName: "FuncA", DstSymbolName: "FuncB", Kind: "calls"},
-		}, map[string]int64{"FuncA": symIDA, "FuncB": symIDB}); err != nil {
+		}, map[string]int64{"FuncA": symIDA, "FuncB": symIDB}, ""); err != nil {
 			return err
 		}
 		return store.InsertEdges(ctx, tx, fileIDC, []types.EdgeRecord{
 			{SrcSymbolName: "FuncC", DstSymbolName: "FuncB", Kind: "calls"},
-		}, map[string]int64{"FuncC": symIDC, "FuncB": symIDB})
+		}, map[string]int64{"FuncC": symIDC, "FuncB": symIDB}, "")
 	}); err != nil {
 		t.Fatalf("InsertEdges: %v", err)
 	}
@@ -419,7 +426,7 @@ func TestNeighbors_DepthClampBelow(t *testing.T) {
 	if err := db.WithWriteTx(func(tx *sql.Tx) error {
 		return store.InsertEdges(ctx, tx, fileID, []types.EdgeRecord{
 			{SrcSymbolName: "FuncA", DstSymbolName: "FuncB", Kind: "calls"},
-		}, map[string]int64{"FuncA": symIDA, "FuncB": symIDB})
+		}, map[string]int64{"FuncA": symIDA, "FuncB": symIDB}, "")
 	}); err != nil {
 		t.Fatalf("setup: %v", err)
 	}
@@ -445,7 +452,7 @@ func TestNeighbors_DepthClampAbove(t *testing.T) {
 	if err := db.WithWriteTx(func(tx *sql.Tx) error {
 		return store.InsertEdges(ctx, tx, fileID, []types.EdgeRecord{
 			{SrcSymbolName: "FuncA", DstSymbolName: "FuncB", Kind: "calls"},
-		}, map[string]int64{"FuncA": symIDA, "FuncB": symIDB})
+		}, map[string]int64{"FuncA": symIDA, "FuncB": symIDB}, "")
 	}); err != nil {
 		t.Fatalf("setup: %v", err)
 	}
@@ -479,7 +486,7 @@ func TestInsertEdges_SkipUnknownSrc(t *testing.T) {
 	}
 
 	err := db.WithWriteTx(func(tx *sql.Tx) error {
-		return store.InsertEdges(ctx, tx, fileID, edges, symbolIDs)
+		return store.InsertEdges(ctx, tx, fileID, edges, symbolIDs, "")
 	})
 	if err != nil {
 		t.Fatalf("InsertEdges: %v", err)
@@ -515,7 +522,7 @@ func TestInsertEdges_CrossFileLookup(t *testing.T) {
 	}
 
 	err := db.WithWriteTx(func(tx *sql.Tx) error {
-		return store.InsertEdges(ctx, tx, fileIDA, edges, symbolIDs)
+		return store.InsertEdges(ctx, tx, fileIDA, edges, symbolIDs, "")
 	})
 	if err != nil {
 		t.Fatalf("InsertEdges: %v", err)
@@ -542,7 +549,7 @@ func TestResolvePendingEdges_NoMatch(t *testing.T) {
 	err := db.WithWriteTx(func(tx *sql.Tx) error {
 		return store.InsertEdges(ctx, tx, fileID, []types.EdgeRecord{
 			{SrcSymbolName: "FuncA", DstSymbolName: "FuncZ", Kind: "calls"},
-		}, map[string]int64{"FuncA": symIDA})
+		}, map[string]int64{"FuncA": symIDA}, "")
 	})
 	if err != nil {
 		t.Fatalf("InsertEdges: %v", err)
@@ -561,6 +568,352 @@ func TestResolvePendingEdges_NoMatch(t *testing.T) {
 	db.QueryRowContext(ctx, "SELECT COUNT(*) FROM pending_edges WHERE dst_symbol_name = 'FuncZ'").Scan(&count)
 	if count != 1 {
 		t.Errorf("expected pending edge to remain, got count=%d", count)
+	}
+}
+
+// ── Language filter and qualified name tests ──
+
+func TestInsertEdges_QualifiedNameAndLanguageStored(t *testing.T) {
+	t.Parallel()
+	db, store := setupTestDB(t)
+	ctx := context.Background()
+
+	fileID, _, symAID := insertTestFileChunkSymbolWithLang(t, store, "MyService.java", "MyService", "java")
+
+	edges := []types.EdgeRecord{
+		{SrcSymbolName: "MyService", DstSymbolName: "List", DstQualifiedName: "java.util.List", Kind: "imports"},
+	}
+	symbolIDs := map[string]int64{"MyService": symAID}
+
+	err := db.WithWriteTx(func(tx *sql.Tx) error {
+		return store.InsertEdges(ctx, tx, fileID, edges, symbolIDs, "java")
+	})
+	if err != nil {
+		t.Fatalf("InsertEdges: %v", err)
+	}
+
+	// Verify pending_edges has correct dst_qualified_name and src_language
+	var qualifiedName, srcLang string
+	err = db.QueryRowContext(ctx,
+		"SELECT dst_qualified_name, src_language FROM pending_edges WHERE dst_symbol_name = 'List'",
+	).Scan(&qualifiedName, &srcLang)
+	if err != nil {
+		t.Fatalf("query pending_edges: %v", err)
+	}
+	if qualifiedName != "java.util.List" {
+		t.Errorf("dst_qualified_name=%q, want %q", qualifiedName, "java.util.List")
+	}
+	if srcLang != "java" {
+		t.Errorf("src_language=%q, want %q", srcLang, "java")
+	}
+}
+
+func TestResolvePendingEdges_LanguageFilter(t *testing.T) {
+	t.Parallel()
+	db, store := setupTestDB(t)
+	ctx := context.Background()
+
+	// Java file imports "Config"
+	javaFileID, _, javaSymID := insertTestFileChunkSymbolWithLang(t, store, "App.java", "App", "java")
+
+	// Insert pending edge from Java for "Config"
+	err := db.WithWriteTx(func(tx *sql.Tx) error {
+		return store.InsertEdges(ctx, tx, javaFileID, []types.EdgeRecord{
+			{SrcSymbolName: "App", DstSymbolName: "Config", DstQualifiedName: "com.example.Config", Kind: "imports"},
+		}, map[string]int64{"App": javaSymID}, "java")
+	})
+	if err != nil {
+		t.Fatalf("InsertEdges: %v", err)
+	}
+
+	// Python file defines "Config" — should NOT resolve the Java pending edge
+	insertTestFileChunkSymbolWithLang(t, store, "config.py", "Config", "python")
+
+	err = db.WithWriteTx(func(tx *sql.Tx) error {
+		return store.ResolvePendingEdges(ctx, tx, []string{"Config"})
+	})
+	if err != nil {
+		t.Fatalf("ResolvePendingEdges: %v", err)
+	}
+
+	// Pending edge should still exist (not resolved to Python symbol)
+	var count int
+	db.QueryRowContext(ctx, "SELECT COUNT(*) FROM pending_edges WHERE dst_symbol_name = 'Config'").Scan(&count)
+	if count != 1 {
+		t.Errorf("expected Java pending edge for Config to remain (not resolve to Python), got count=%d", count)
+	}
+
+	// No resolved edge should exist
+	neighbors, err := store.Neighbors(ctx, javaSymID, 1, "outgoing")
+	if err != nil {
+		t.Fatalf("Neighbors: %v", err)
+	}
+	if len(neighbors) != 0 {
+		t.Errorf("expected 0 resolved neighbors (cross-language should not resolve), got %d", len(neighbors))
+	}
+}
+
+func TestResolvePendingEdges_SameLanguageResolves(t *testing.T) {
+	t.Parallel()
+	db, store := setupTestDB(t)
+	ctx := context.Background()
+
+	// Java file imports "Config"
+	javaFileID, _, javaSymID := insertTestFileChunkSymbolWithLang(t, store, "App.java", "App", "java")
+
+	err := db.WithWriteTx(func(tx *sql.Tx) error {
+		return store.InsertEdges(ctx, tx, javaFileID, []types.EdgeRecord{
+			{SrcSymbolName: "App", DstSymbolName: "Config", DstQualifiedName: "com.example.Config", Kind: "imports"},
+		}, map[string]int64{"App": javaSymID}, "java")
+	})
+	if err != nil {
+		t.Fatalf("InsertEdges: %v", err)
+	}
+
+	// Java file defines "Config" — should resolve the Java pending edge
+	_, _, javaConfigID := insertTestFileChunkSymbolWithLang(t, store, "Config.java", "Config", "java")
+
+	err = db.WithWriteTx(func(tx *sql.Tx) error {
+		return store.ResolvePendingEdges(ctx, tx, []string{"Config"})
+	})
+	if err != nil {
+		t.Fatalf("ResolvePendingEdges: %v", err)
+	}
+
+	// Pending edge should be resolved
+	var count int
+	db.QueryRowContext(ctx, "SELECT COUNT(*) FROM pending_edges WHERE dst_symbol_name = 'Config'").Scan(&count)
+	if count != 0 {
+		t.Errorf("expected pending edge to be resolved, got count=%d", count)
+	}
+
+	// Resolved edge should exist
+	neighbors, err := store.Neighbors(ctx, javaSymID, 1, "outgoing")
+	if err != nil {
+		t.Fatalf("Neighbors: %v", err)
+	}
+	if len(neighbors) != 1 || neighbors[0] != javaConfigID {
+		t.Errorf("expected resolved edge to Java Config (%d), got %v", javaConfigID, neighbors)
+	}
+}
+
+func TestLookupSymbolIDTx_LanguageFilter(t *testing.T) {
+	t.Parallel()
+	db, store := setupTestDB(t)
+	ctx := context.Background()
+
+	// Create Config in both Python and Java
+	_, _, pyConfigID := insertTestFileChunkSymbolWithLang(t, store, "config.py", "Config", "python")
+	_, _, javaConfigID := insertTestFileChunkSymbolWithLang(t, store, "Config.java", "Config", "java")
+
+	// lookupSymbolIDTx with language="java" should return the Java symbol
+	var gotID int64
+	err := db.WithWriteTx(func(tx *sql.Tx) error {
+		var lookupErr error
+		gotID, lookupErr = lookupSymbolIDTx(ctx, tx, "Config", 0, "java")
+		return lookupErr
+	})
+	if err != nil {
+		t.Fatalf("lookupSymbolIDTx: %v", err)
+	}
+	if gotID != javaConfigID {
+		t.Errorf("lookupSymbolIDTx(Config, java)=%d, want %d (Java); Python=%d", gotID, javaConfigID, pyConfigID)
+	}
+
+	// lookupSymbolIDTx with language="python" should return the Python symbol
+	err = db.WithWriteTx(func(tx *sql.Tx) error {
+		var lookupErr error
+		gotID, lookupErr = lookupSymbolIDTx(ctx, tx, "Config", 0, "python")
+		return lookupErr
+	})
+	if err != nil {
+		t.Fatalf("lookupSymbolIDTx: %v", err)
+	}
+	if gotID != pyConfigID {
+		t.Errorf("lookupSymbolIDTx(Config, python)=%d, want %d (Python)", gotID, pyConfigID)
+	}
+
+	// lookupSymbolIDTx with language="" falls back to global (any match)
+	err = db.WithWriteTx(func(tx *sql.Tx) error {
+		var lookupErr error
+		gotID, lookupErr = lookupSymbolIDTx(ctx, tx, "Config", 0, "")
+		return lookupErr
+	})
+	if err != nil {
+		t.Fatalf("lookupSymbolIDTx: %v", err)
+	}
+	if gotID == 0 {
+		t.Error("lookupSymbolIDTx(Config, '') returned 0, want any Config symbol")
+	}
+}
+
+func TestIntegration_CrossLanguageNoMisresolution(t *testing.T) {
+	t.Parallel()
+	db, store := setupTestDB(t)
+	ctx := context.Background()
+
+	// Polyglot scenario: Python defines Config, Java imports Config
+	insertTestFileChunkSymbolWithLang(t, store, "config.py", "Config", "python")
+
+	javaFileID, _, javaSymID := insertTestFileChunkSymbolWithLang(t, store, "App.java", "App", "java")
+
+	// Java imports Config — should NOT resolve to Python Config
+	err := db.WithWriteTx(func(tx *sql.Tx) error {
+		return store.InsertEdges(ctx, tx, javaFileID, []types.EdgeRecord{
+			{SrcSymbolName: "App", DstSymbolName: "Config", DstQualifiedName: "com.example.Config", Kind: "imports"},
+		}, map[string]int64{"App": javaSymID}, "java")
+	})
+	if err != nil {
+		t.Fatalf("InsertEdges: %v", err)
+	}
+
+	// Config should be in pending_edges, not resolved
+	var count int
+	db.QueryRowContext(ctx, "SELECT COUNT(*) FROM pending_edges WHERE dst_symbol_name = 'Config'").Scan(&count)
+	if count != 1 {
+		t.Fatalf("expected 1 pending edge for Config, got %d", count)
+	}
+
+	// No resolved edge from App
+	neighbors, err := store.Neighbors(ctx, javaSymID, 1, "outgoing")
+	if err != nil {
+		t.Fatalf("Neighbors: %v", err)
+	}
+	if len(neighbors) != 0 {
+		t.Errorf("expected no resolved edges (Java→Python should not resolve), got %d", len(neighbors))
+	}
+}
+
+func TestMigration_V2toV3(t *testing.T) {
+	t.Parallel()
+
+	// Create a DB at v2 (before our migration)
+	db, err := Open(OpenInput{InMemory: true})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+
+	// Apply base schema and v1→v2 migration manually
+	err = db.WithWriteTx(func(tx *sql.Tx) error {
+		for _, stmt := range schemaV1 {
+			if _, err := tx.Exec(stmt); err != nil {
+				return err
+			}
+		}
+		for _, stmt := range ftsTriggers {
+			if _, err := tx.Exec(stmt); err != nil {
+				return err
+			}
+		}
+		for _, stmt := range migrationsV1toV2 {
+			if _, execErr := tx.Exec(stmt); execErr != nil {
+				if isDuplicateColumnError(execErr) {
+					continue
+				}
+				return execErr
+			}
+		}
+		_, err := tx.Exec("INSERT INTO schema_version (version) VALUES (2)")
+		return err
+	})
+	if err != nil {
+		t.Fatalf("setup v2 schema: %v", err)
+	}
+
+	// Run full Migrate — should apply v2→v3
+	if err := Migrate(db); err != nil {
+		t.Fatalf("Migrate v2→v3: %v", err)
+	}
+
+	// Create a file, chunk, and symbol so we have a valid src_symbol_id
+	ctx := context.Background()
+	err = db.WithWriteTx(func(tx *sql.Tx) error {
+		if _, execErr := tx.ExecContext(ctx,
+			"INSERT INTO files (path, content_hash, mtime, language) VALUES ('test.java', 'h1', 1.0, 'java')"); execErr != nil {
+			return execErr
+		}
+		if _, execErr := tx.ExecContext(ctx,
+			"INSERT INTO chunks (file_id, chunk_index, kind, start_line, end_line, content, token_count) VALUES (1, 0, 'class', 1, 10, 'class App {}', 5)"); execErr != nil {
+			return execErr
+		}
+		if _, execErr := tx.ExecContext(ctx,
+			"INSERT INTO symbols (chunk_id, file_id, name, kind, line) VALUES (1, 1, 'App', 'class', 1)"); execErr != nil {
+			return execErr
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("setup test data: %v", err)
+	}
+
+	// Verify new columns exist by inserting a pending edge with them
+	err = db.WithWriteTx(func(tx *sql.Tx) error {
+		_, execErr := tx.ExecContext(ctx,
+			"INSERT INTO pending_edges (src_symbol_id, dst_symbol_name, dst_qualified_name, kind, src_language) VALUES (1, 'Foo', 'com.example.Foo', 'imports', 'java')")
+		return execErr
+	})
+	if err != nil {
+		t.Fatalf("insert with new columns failed: %v", err)
+	}
+
+	// Verify the values
+	var qualifiedName, srcLang string
+	err = db.QueryRowContext(ctx,
+		"SELECT dst_qualified_name, src_language FROM pending_edges WHERE dst_symbol_name = 'Foo'",
+	).Scan(&qualifiedName, &srcLang)
+	if err != nil {
+		t.Fatalf("query new columns: %v", err)
+	}
+	if qualifiedName != "com.example.Foo" {
+		t.Errorf("dst_qualified_name=%q, want %q", qualifiedName, "com.example.Foo")
+	}
+	if srcLang != "java" {
+		t.Errorf("src_language=%q, want %q", srcLang, "java")
+	}
+
+	// Verify schema version is 3
+	var version int
+	db.QueryRowContext(ctx, "SELECT MAX(version) FROM schema_version").Scan(&version)
+	if version != 3 {
+		t.Errorf("schema version=%d, want 3", version)
+	}
+}
+
+func TestResolvePendingEdges_BackwardCompat_EmptyLanguage(t *testing.T) {
+	t.Parallel()
+	db, store := setupTestDB(t)
+	ctx := context.Background()
+
+	// Simulate pre-migration pending edge with empty src_language
+	fileID, _, symAID := insertTestFileChunkSymbol(t, store, "a.go", "FuncA")
+	err := db.WithWriteTx(func(tx *sql.Tx) error {
+		// Insert with empty language (like pre-migration data)
+		return store.InsertEdges(ctx, tx, fileID, []types.EdgeRecord{
+			{SrcSymbolName: "FuncA", DstSymbolName: "FuncZ", Kind: "calls"},
+		}, map[string]int64{"FuncA": symAID}, "")
+	})
+	if err != nil {
+		t.Fatalf("InsertEdges: %v", err)
+	}
+
+	// Create FuncZ
+	_, _, symZID := insertTestFileChunkSymbol(t, store, "z.go", "FuncZ")
+
+	// Resolve — should work even with empty src_language (backward compat fallback)
+	err = db.WithWriteTx(func(tx *sql.Tx) error {
+		return store.ResolvePendingEdges(ctx, tx, []string{"FuncZ"})
+	})
+	if err != nil {
+		t.Fatalf("ResolvePendingEdges: %v", err)
+	}
+
+	neighbors, err := store.Neighbors(ctx, symAID, 1, "outgoing")
+	if err != nil {
+		t.Fatalf("Neighbors: %v", err)
+	}
+	if len(neighbors) != 1 || neighbors[0] != symZID {
+		t.Errorf("expected edge to FuncZ (%d), got %v", symZID, neighbors)
 	}
 }
 

--- a/internal/storage/schema.go
+++ b/internal/storage/schema.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-const schemaVersion = 2
+const schemaVersion = 3
 
 // schemaV1 contains all DDL statements for schema version 1.
 // Tables: files, chunks, symbols, edges, pending_edges, diff_log, diff_symbols,
@@ -229,6 +229,13 @@ var migrationsV1toV2 = []string{
 	`CREATE INDEX IF NOT EXISTS idx_chunks_embedded ON chunks(embedded, id)`,
 }
 
+// migrationsV2toV3 adds qualified name and source language to pending_edges
+// for disambiguation of short-name collisions and cross-language misresolution.
+var migrationsV2toV3 = []string{
+	`ALTER TABLE pending_edges ADD COLUMN dst_qualified_name TEXT DEFAULT ''`,
+	`ALTER TABLE pending_edges ADD COLUMN src_language TEXT DEFAULT ''`,
+}
+
 // currentSchemaVersion returns the highest version recorded, or 0 if the
 // schema_version table does not yet exist.
 func currentSchemaVersion(tx *sql.Tx) (int, error) {
@@ -273,6 +280,17 @@ func Migrate(db *DB) error {
 						continue
 					}
 					return fmt.Errorf("migrate v1→v2: %w", err)
+				}
+			}
+		}
+
+		if cur < 3 {
+			for _, stmt := range migrationsV2toV3 {
+				if _, err := tx.Exec(stmt); err != nil {
+					if isDuplicateColumnError(err) {
+						continue
+					}
+					return fmt.Errorf("migrate v2→v3: %w", err)
 				}
 			}
 		}

--- a/internal/types/entities.go
+++ b/internal/types/entities.go
@@ -53,14 +53,15 @@ type SymbolRecord struct {
 
 // EdgeRecord represents a dependency edge between two symbols.
 type EdgeRecord struct {
-	ID            int64
-	SrcSymbolID   int64
-	DstSymbolID   int64
-	SrcSymbolName string // set by parser, resolved to ID during write
-	DstSymbolName string // set by parser, resolved to ID during write
-	Kind          string // imports | calls | type_ref | inherits | implements
-	FileID        int64
-	IsCrossFile   bool
+	ID               int64
+	SrcSymbolID      int64
+	DstSymbolID      int64
+	SrcSymbolName    string // set by parser, resolved to ID during write
+	DstSymbolName    string // set by parser, resolved to ID during write
+	DstQualifiedName string // full import path (e.g. "java.util.List", "fmt", "std::collections::HashMap")
+	Kind             string // imports | calls | type_ref | inherits | implements
+	FileID           int64
+	IsCrossFile      bool
 }
 
 // WriteJobType distinguishes the kind of write operation.


### PR DESCRIPTION
add qualified names and language filtering to prevent cross-language misresolution

Adds dst_qualified_name and src_language columns to pending_edges (schema v3) so that import edges carry the full import path and source language. Updates lookupSymbolIDTx to prefer same-language matches and reject cross-language candidates, preventing a Java import from resolving to a Python symbol with the same short name. All 6 language import handlers now extract qualified paths (e.g. "java.util.List", "net/http", "std::collections::HashMap").

Closes #16