### PR TITLE
feat(config): add database, postgres, qdrant, and embedding TOML sections

### DIFF
--- a/cmd/shaktiman/main.go
+++ b/cmd/shaktiman/main.go
@@ -79,8 +79,11 @@ func initCmd() *cobra.Command {
 
 func indexCmd() *cobra.Command {
 	var (
-		embed         bool
-		vectorBackend string
+		embed          bool
+		vectorBackend  string
+		dbBackend      string
+		postgresURL    string
+		qdrantURL      string
 	)
 	cmd := &cobra.Command{
 		Use:   "index <project-root>",
@@ -96,12 +99,30 @@ func indexCmd() *cobra.Command {
 				return fmt.Errorf("load config: %w", err)
 			}
 
-			// CLI --vector flag overrides TOML and default
+			// CLI flags override TOML and default
 			if vectorBackend != "" {
-				if vectorBackend != "brute_force" && vectorBackend != "hnsw" {
-					return fmt.Errorf("--vector must be 'brute_force' or 'hnsw', got %q", vectorBackend)
+				switch vectorBackend {
+				case "brute_force", "hnsw", "qdrant", "pgvector":
+					cfg.VectorBackend = vectorBackend
+				default:
+					return fmt.Errorf("--vector must be 'brute_force', 'hnsw', 'qdrant', or 'pgvector', got %q", vectorBackend)
 				}
-				cfg.VectorBackend = vectorBackend
+			}
+			if dbBackend != "" {
+				if dbBackend != "sqlite" && dbBackend != "postgres" {
+					return fmt.Errorf("--db must be 'sqlite' or 'postgres', got %q", dbBackend)
+				}
+				cfg.DatabaseBackend = dbBackend
+			}
+			if postgresURL != "" {
+				cfg.PostgresConnString = postgresURL
+			}
+			if qdrantURL != "" {
+				cfg.QdrantURL = qdrantURL
+			}
+
+			if err := types.ValidateBackendConfig(cfg); err != nil {
+				return err
 			}
 
 			// Signal handling for graceful shutdown
@@ -199,7 +220,10 @@ func indexCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVar(&embed, "embed", false, "Also generate embeddings (requires Ollama)")
-	cmd.Flags().StringVar(&vectorBackend, "vector", "", `Vector backend: "brute_force" or "hnsw"`)
+	cmd.Flags().StringVar(&vectorBackend, "vector", "", `Vector backend: "brute_force", "hnsw", "qdrant", or "pgvector"`)
+	cmd.Flags().StringVar(&dbBackend, "db", "", `Database backend: "sqlite" or "postgres"`)
+	cmd.Flags().StringVar(&postgresURL, "postgres-url", "", "PostgreSQL connection string (overrides TOML)")
+	cmd.Flags().StringVar(&qdrantURL, "qdrant-url", "", "Qdrant URL (overrides TOML)")
 	return cmd
 }
 

--- a/cmd/shaktimand/main.go
+++ b/cmd/shaktimand/main.go
@@ -75,6 +75,11 @@ func main() {
 		os.Exit(1)
 	}
 
+	if err := types.ValidateBackendConfig(cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 

--- a/internal/daemon/writer.go
+++ b/internal/daemon/writer.go
@@ -207,7 +207,7 @@ func processWriteJob(ctx context.Context, tx *sql.Tx, store *storage.Store, logg
 // collectChunkIDsByPath returns all chunk IDs for a file path (before deletion).
 func collectChunkIDsByPath(ctx context.Context, tx *sql.Tx, path string) []int64 {
 	rows, err := tx.QueryContext(ctx,
-		"SELECT c.id FROM chunks c JOIN files f ON c.file_id = f.id WHERE f.path = ?", path)
+		"SELECT c.id FROM chunks c JOIN files f ON c.file_id = f.id WHERE f.path = ? AND c.embedded = 1", path)
 	if err != nil {
 		return nil
 	}
@@ -291,7 +291,7 @@ func processEnrichmentJob(ctx context.Context, tx *sql.Tx, store *storage.Store,
 	// Collect old chunk IDs for vector store cleanup before deleting
 	var staleChunkIDs []int64
 	{
-		rows, qerr := tx.QueryContext(ctx, "SELECT id FROM chunks WHERE file_id = ?", fileID)
+		rows, qerr := tx.QueryContext(ctx, "SELECT id FROM chunks WHERE file_id = ? AND embedded = 1", fileID)
 		if qerr == nil {
 			for rows.Next() {
 				var cid int64

--- a/internal/types/config.go
+++ b/internal/types/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"time"
 
 	"github.com/BurntSushi/toml"
 )
@@ -41,7 +42,24 @@ type Config struct {
 	ContextBudgetTokens int  // 256-32768, default 4096
 
 	// Vector backend configuration
-	VectorBackend string // "brute_force" (default) or "hnsw"
+	VectorBackend string // "brute_force" (default), "hnsw", "qdrant", or "pgvector"
+
+	// Database backend configuration
+	DatabaseBackend string // "sqlite" (default) or "postgres"
+
+	// PostgreSQL configuration (used when DatabaseBackend = "postgres")
+	PostgresConnString string
+	PostgresMaxOpen    int    // connection pool max open (default: 20)
+	PostgresMaxIdle    int    // connection pool max idle (default: 10)
+	PostgresSchema     string // Postgres schema name (default: "public")
+
+	// Qdrant configuration (used when VectorBackend = "qdrant")
+	QdrantURL        string // Qdrant HTTP API URL (e.g. "http://localhost:6334")
+	QdrantCollection string // collection name (default: "shaktiman")
+	QdrantAPIKey     string // optional API key (prefer env var SHAKTIMAN_QDRANT_API_KEY)
+
+	// Embedding timeout
+	EmbedTimeout time.Duration // HTTP timeout per embedding request (default: 120s)
 
 	// Test file detection patterns (glob patterns and directory prefixes)
 	TestPatterns []string // e.g. ["*_test.go", "testdata/", "*.test.ts"]
@@ -73,17 +91,30 @@ func DefaultConfig(projectRoot string) Config {
 		ContextEnabled:      true,
 		ContextBudgetTokens: 4096,
 
-		VectorBackend: "brute_force",
+		VectorBackend:   "brute_force",
+		DatabaseBackend: "sqlite",
+
+		PostgresMaxOpen: 20,
+		PostgresMaxIdle: 10,
+		PostgresSchema:  "public",
+
+		QdrantCollection: "shaktiman",
+
+		EmbedTimeout: 120 * time.Second,
 	}
 }
 
 // tomlConfig mirrors the TOML file structure for deserialization.
 // Pointer fields distinguish "key present" from "key absent".
 type tomlConfig struct {
-	Search  tomlSearch  `toml:"search"`
-	Context tomlContext `toml:"context"`
-	Vector  tomlVector  `toml:"vector"`
-	Test    tomlTest    `toml:"test"`
+	Database  tomlDatabase  `toml:"database"`
+	Postgres  tomlPostgres  `toml:"postgres"`
+	Search    tomlSearch    `toml:"search"`
+	Context   tomlContext   `toml:"context"`
+	Vector    tomlVector    `toml:"vector"`
+	Qdrant    tomlQdrant    `toml:"qdrant"`
+	Embedding tomlEmbedding `toml:"embedding"`
+	Test      tomlTest      `toml:"test"`
 }
 
 type tomlVector struct {
@@ -103,6 +134,31 @@ type tomlContext struct {
 
 type tomlTest struct {
 	Patterns []string `toml:"patterns"`
+}
+
+type tomlDatabase struct {
+	Backend *string `toml:"backend"`
+}
+
+type tomlPostgres struct {
+	ConnectionString *string `toml:"connection_string"`
+	MaxOpenConns     *int    `toml:"max_open_conns"`
+	MaxIdleConns     *int    `toml:"max_idle_conns"`
+	Schema           *string `toml:"schema"`
+}
+
+type tomlQdrant struct {
+	URL        *string `toml:"url"`
+	Collection *string `toml:"collection"`
+	APIKey     *string `toml:"api_key"`
+}
+
+type tomlEmbedding struct {
+	OllamaURL *string `toml:"ollama_url"`
+	Model     *string `toml:"model"`
+	Dims      *int    `toml:"dims"`
+	BatchSize *int    `toml:"batch_size"`
+	Timeout   *string `toml:"timeout"`
 }
 
 // LoadConfigFromFile reads shaktiman.toml and merges values into cfg.
@@ -154,32 +210,144 @@ func LoadConfigFromFile(cfg Config) (Config, error) {
 		cfg.MaxBudgetTokens = *v
 	}
 	if v := tc.Vector.Backend; v != nil {
-		if *v != "brute_force" && *v != "hnsw" {
-			return cfg, fmt.Errorf("config: vector.backend must be 'brute_force' or 'hnsw', got %q", *v)
+		switch *v {
+		case "brute_force", "hnsw", "qdrant", "pgvector":
+			cfg.VectorBackend = *v
+		default:
+			return cfg, fmt.Errorf("config: vector.backend must be 'brute_force', 'hnsw', 'qdrant', or 'pgvector', got %q", *v)
 		}
-		cfg.VectorBackend = *v
 	}
 	if len(tc.Test.Patterns) > 0 {
 		cfg.TestPatterns = tc.Test.Patterns
 	}
 
+	// [database] section
+	if v := tc.Database.Backend; v != nil {
+		if *v != "sqlite" && *v != "postgres" {
+			return cfg, fmt.Errorf("config: database.backend must be 'sqlite' or 'postgres', got %q", *v)
+		}
+		cfg.DatabaseBackend = *v
+	}
+
+	// [postgres] section
+	if v := tc.Postgres.ConnectionString; v != nil {
+		cfg.PostgresConnString = *v
+	}
+	if v := tc.Postgres.MaxOpenConns; v != nil {
+		if *v < 1 {
+			return cfg, fmt.Errorf("config: postgres.max_open_conns must be >= 1, got %d", *v)
+		}
+		cfg.PostgresMaxOpen = *v
+	}
+	if v := tc.Postgres.MaxIdleConns; v != nil {
+		if *v < 0 {
+			return cfg, fmt.Errorf("config: postgres.max_idle_conns must be >= 0, got %d", *v)
+		}
+		cfg.PostgresMaxIdle = *v
+	}
+	if v := tc.Postgres.Schema; v != nil {
+		cfg.PostgresSchema = *v
+	}
+
+	// [qdrant] section
+	if v := tc.Qdrant.URL; v != nil {
+		cfg.QdrantURL = *v
+	}
+	if v := tc.Qdrant.Collection; v != nil {
+		cfg.QdrantCollection = *v
+	}
+	if v := tc.Qdrant.APIKey; v != nil {
+		cfg.QdrantAPIKey = *v
+	}
+
+	// [embedding] section
+	if v := tc.Embedding.OllamaURL; v != nil {
+		cfg.OllamaURL = *v
+	}
+	if v := tc.Embedding.Model; v != nil {
+		cfg.EmbeddingModel = *v
+	}
+	if v := tc.Embedding.Dims; v != nil {
+		if *v < 1 || *v > 4096 {
+			return cfg, fmt.Errorf("config: embedding.dims must be 1-4096, got %d", *v)
+		}
+		cfg.EmbeddingDims = *v
+	}
+	if v := tc.Embedding.BatchSize; v != nil {
+		if *v < 1 {
+			return cfg, fmt.Errorf("config: embedding.batch_size must be >= 1, got %d", *v)
+		}
+		cfg.EmbedBatchSize = *v
+	}
+	if v := tc.Embedding.Timeout; v != nil {
+		d, err := time.ParseDuration(*v)
+		if err != nil {
+			return cfg, fmt.Errorf("config: embedding.timeout: %w", err)
+		}
+		cfg.EmbedTimeout = d
+	}
+
+	// Environment variable overrides for secrets (highest priority after CLI flags)
+	if v := os.Getenv("SHAKTIMAN_POSTGRES_URL"); v != "" {
+		cfg.PostgresConnString = v
+	}
+	if v := os.Getenv("SHAKTIMAN_QDRANT_API_KEY"); v != "" {
+		cfg.QdrantAPIKey = v
+	}
+
 	return cfg, nil
+}
+
+// ValidateBackendConfig checks that the configured backend combination is valid.
+// Call after all config sources (defaults, TOML, env, CLI) have been merged.
+func ValidateBackendConfig(cfg Config) error {
+	if cfg.VectorBackend == "pgvector" && cfg.DatabaseBackend != "postgres" {
+		return fmt.Errorf("config: vector.backend 'pgvector' requires database.backend 'postgres'")
+	}
+	if cfg.DatabaseBackend == "postgres" && cfg.PostgresConnString == "" {
+		return fmt.Errorf("config: database.backend 'postgres' requires postgres.connection_string or SHAKTIMAN_POSTGRES_URL")
+	}
+	if cfg.VectorBackend == "qdrant" && cfg.QdrantURL == "" {
+		return fmt.Errorf("config: vector.backend 'qdrant' requires qdrant.url")
+	}
+	return nil
 }
 
 const sampleConfig = `# Shaktiman configuration
 # Uncomment and modify values to override defaults.
 
+[database]
+# backend = "sqlite"             # "sqlite" (default) or "postgres"
+
+[postgres]
+# connection_string = "postgres://user:pass@localhost:5432/shaktiman?sslmode=disable"
+# max_open_conns = 20            # Connection pool max open (default: 20)
+# max_idle_conns = 10            # Connection pool max idle (default: 10)
+# schema = "public"              # Postgres schema (default: "public")
+
 [search]
-# max_results = 10        # Max results per search (1-200)
-# default_mode = "locate"  # "locate" (headers only) or "full" (with source code)
-# min_score = 0.15         # Drop results below this relevance score (0.0-1.0)
+# max_results = 10               # Max results per search (1-200)
+# default_mode = "locate"        # "locate" (headers only) or "full" (with source code)
+# min_score = 0.15               # Drop results below this relevance score (0.0-1.0)
 
 [context]
-# enabled = true           # Set false to disable the context tool entirely
-# budget_tokens = 4096     # Default token budget for context assembly (256-32768)
+# enabled = true                 # Set false to disable the context tool entirely
+# budget_tokens = 4096           # Default token budget for context assembly (256-32768)
 
 [vector]
-# backend = "brute_force"  # "brute_force" or "hnsw"
+# backend = "brute_force"        # "brute_force", "hnsw", "qdrant", or "pgvector"
+
+[qdrant]
+# url = "http://localhost:6334"  # Qdrant HTTP API URL
+# collection = "shaktiman"       # Collection name (default: "shaktiman")
+# api_key = ""                   # API key (prefer env var SHAKTIMAN_QDRANT_API_KEY)
+
+[embedding]
+# ollama_url = "http://localhost:11434"  # Ollama API base URL
+# model = "nomic-embed-text"             # Embedding model name
+# dims = 768                             # Vector dimensionality
+# batch_size = 128                       # Texts per batch request
+# timeout = "120s"                       # HTTP timeout per request
 
 [test]
 # patterns = ["*_test.go", "testdata/"]  # Glob patterns identifying test files

--- a/internal/types/config_test.go
+++ b/internal/types/config_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestDefaultConfig(t *testing.T) {
@@ -25,6 +26,24 @@ func TestDefaultConfig(t *testing.T) {
 	}
 	if cfg.VectorBackend != "brute_force" {
 		t.Errorf("VectorBackend = %q, want brute_force", cfg.VectorBackend)
+	}
+	if cfg.DatabaseBackend != "sqlite" {
+		t.Errorf("DatabaseBackend = %q, want sqlite", cfg.DatabaseBackend)
+	}
+	if cfg.PostgresMaxOpen != 20 {
+		t.Errorf("PostgresMaxOpen = %d, want 20", cfg.PostgresMaxOpen)
+	}
+	if cfg.PostgresMaxIdle != 10 {
+		t.Errorf("PostgresMaxIdle = %d, want 10", cfg.PostgresMaxIdle)
+	}
+	if cfg.PostgresSchema != "public" {
+		t.Errorf("PostgresSchema = %q, want public", cfg.PostgresSchema)
+	}
+	if cfg.QdrantCollection != "shaktiman" {
+		t.Errorf("QdrantCollection = %q, want shaktiman", cfg.QdrantCollection)
+	}
+	if cfg.EmbedTimeout != 120*time.Second {
+		t.Errorf("EmbedTimeout = %v, want 120s", cfg.EmbedTimeout)
 	}
 }
 
@@ -140,6 +159,238 @@ max_results = 5
 	}
 }
 
+func TestLoadConfigFromFile_DatabaseSection(t *testing.T) {
+	dir := t.TempDir()
+	cfgDir := filepath.Join(dir, ".shaktiman")
+	os.MkdirAll(cfgDir, 0o755)
+
+	tomlData := `[database]
+backend = "postgres"
+
+[postgres]
+connection_string = "postgres://localhost:5432/shaktiman"
+max_open_conns = 30
+max_idle_conns = 15
+schema = "myschema"
+`
+	os.WriteFile(filepath.Join(cfgDir, "shaktiman.toml"), []byte(tomlData), 0o644)
+
+	cfg := DefaultConfig(dir)
+	loaded, err := LoadConfigFromFile(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if loaded.DatabaseBackend != "postgres" {
+		t.Errorf("DatabaseBackend = %q, want postgres", loaded.DatabaseBackend)
+	}
+	if loaded.PostgresConnString != "postgres://localhost:5432/shaktiman" {
+		t.Errorf("PostgresConnString = %q", loaded.PostgresConnString)
+	}
+	if loaded.PostgresMaxOpen != 30 {
+		t.Errorf("PostgresMaxOpen = %d, want 30", loaded.PostgresMaxOpen)
+	}
+	if loaded.PostgresMaxIdle != 15 {
+		t.Errorf("PostgresMaxIdle = %d, want 15", loaded.PostgresMaxIdle)
+	}
+	if loaded.PostgresSchema != "myschema" {
+		t.Errorf("PostgresSchema = %q, want myschema", loaded.PostgresSchema)
+	}
+}
+
+func TestLoadConfigFromFile_QdrantSection(t *testing.T) {
+	dir := t.TempDir()
+	cfgDir := filepath.Join(dir, ".shaktiman")
+	os.MkdirAll(cfgDir, 0o755)
+
+	tomlData := `[vector]
+backend = "qdrant"
+
+[qdrant]
+url = "http://localhost:6334"
+collection = "my_index"
+api_key = "secret"
+`
+	os.WriteFile(filepath.Join(cfgDir, "shaktiman.toml"), []byte(tomlData), 0o644)
+
+	cfg := DefaultConfig(dir)
+	loaded, err := LoadConfigFromFile(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if loaded.VectorBackend != "qdrant" {
+		t.Errorf("VectorBackend = %q, want qdrant", loaded.VectorBackend)
+	}
+	if loaded.QdrantURL != "http://localhost:6334" {
+		t.Errorf("QdrantURL = %q", loaded.QdrantURL)
+	}
+	if loaded.QdrantCollection != "my_index" {
+		t.Errorf("QdrantCollection = %q, want my_index", loaded.QdrantCollection)
+	}
+	if loaded.QdrantAPIKey != "secret" {
+		t.Errorf("QdrantAPIKey = %q, want secret", loaded.QdrantAPIKey)
+	}
+}
+
+func TestLoadConfigFromFile_EmbeddingSection(t *testing.T) {
+	dir := t.TempDir()
+	cfgDir := filepath.Join(dir, ".shaktiman")
+	os.MkdirAll(cfgDir, 0o755)
+
+	tomlData := `[embedding]
+ollama_url = "http://remote:11434"
+model = "all-minilm"
+dims = 384
+batch_size = 64
+timeout = "60s"
+`
+	os.WriteFile(filepath.Join(cfgDir, "shaktiman.toml"), []byte(tomlData), 0o644)
+
+	cfg := DefaultConfig(dir)
+	loaded, err := LoadConfigFromFile(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if loaded.OllamaURL != "http://remote:11434" {
+		t.Errorf("OllamaURL = %q", loaded.OllamaURL)
+	}
+	if loaded.EmbeddingModel != "all-minilm" {
+		t.Errorf("EmbeddingModel = %q, want all-minilm", loaded.EmbeddingModel)
+	}
+	if loaded.EmbeddingDims != 384 {
+		t.Errorf("EmbeddingDims = %d, want 384", loaded.EmbeddingDims)
+	}
+	if loaded.EmbedBatchSize != 64 {
+		t.Errorf("EmbedBatchSize = %d, want 64", loaded.EmbedBatchSize)
+	}
+	if loaded.EmbedTimeout != 60*time.Second {
+		t.Errorf("EmbedTimeout = %v, want 60s", loaded.EmbedTimeout)
+	}
+}
+
+func TestLoadConfigFromFile_EnvVarOverrides(t *testing.T) {
+	dir := t.TempDir()
+	cfgDir := filepath.Join(dir, ".shaktiman")
+	os.MkdirAll(cfgDir, 0o755)
+
+	tomlData := `[postgres]
+connection_string = "postgres://toml-value"
+
+[qdrant]
+api_key = "toml-key"
+`
+	os.WriteFile(filepath.Join(cfgDir, "shaktiman.toml"), []byte(tomlData), 0o644)
+
+	// Env vars override TOML
+	t.Setenv("SHAKTIMAN_POSTGRES_URL", "postgres://env-value")
+	t.Setenv("SHAKTIMAN_QDRANT_API_KEY", "env-key")
+
+	cfg := DefaultConfig(dir)
+	loaded, err := LoadConfigFromFile(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if loaded.PostgresConnString != "postgres://env-value" {
+		t.Errorf("PostgresConnString = %q, want postgres://env-value (env should override TOML)", loaded.PostgresConnString)
+	}
+	if loaded.QdrantAPIKey != "env-key" {
+		t.Errorf("QdrantAPIKey = %q, want env-key (env should override TOML)", loaded.QdrantAPIKey)
+	}
+}
+
+func TestLoadConfigFromFile_PgvectorBackend(t *testing.T) {
+	dir := t.TempDir()
+	cfgDir := filepath.Join(dir, ".shaktiman")
+	os.MkdirAll(cfgDir, 0o755)
+
+	tomlData := `[vector]
+backend = "pgvector"
+`
+	os.WriteFile(filepath.Join(cfgDir, "shaktiman.toml"), []byte(tomlData), 0o644)
+
+	cfg := DefaultConfig(dir)
+	loaded, err := LoadConfigFromFile(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if loaded.VectorBackend != "pgvector" {
+		t.Errorf("VectorBackend = %q, want pgvector", loaded.VectorBackend)
+	}
+}
+
+func TestValidateBackendConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		modify  func(*Config)
+		wantErr bool
+	}{
+		{
+			name:    "default config is valid",
+			modify:  func(c *Config) {},
+			wantErr: false,
+		},
+		{
+			name: "pgvector requires postgres",
+			modify: func(c *Config) {
+				c.VectorBackend = "pgvector"
+				c.DatabaseBackend = "sqlite"
+			},
+			wantErr: true,
+		},
+		{
+			name: "pgvector with postgres is valid",
+			modify: func(c *Config) {
+				c.VectorBackend = "pgvector"
+				c.DatabaseBackend = "postgres"
+				c.PostgresConnString = "postgres://localhost/db"
+			},
+			wantErr: false,
+		},
+		{
+			name: "postgres requires connection string",
+			modify: func(c *Config) {
+				c.DatabaseBackend = "postgres"
+				c.PostgresConnString = ""
+			},
+			wantErr: true,
+		},
+		{
+			name: "postgres with connection string is valid",
+			modify: func(c *Config) {
+				c.DatabaseBackend = "postgres"
+				c.PostgresConnString = "postgres://localhost/db"
+			},
+			wantErr: false,
+		},
+		{
+			name: "qdrant requires url",
+			modify: func(c *Config) {
+				c.VectorBackend = "qdrant"
+				c.QdrantURL = ""
+			},
+			wantErr: true,
+		},
+		{
+			name: "qdrant with url is valid",
+			modify: func(c *Config) {
+				c.VectorBackend = "qdrant"
+				c.QdrantURL = "http://localhost:6334"
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := DefaultConfig("/tmp/proj")
+			tt.modify(&cfg)
+			err := ValidateBackendConfig(cfg)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateBackendConfig() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestLoadConfigFromFile_InvalidValues(t *testing.T) {
 	tests := []struct {
 		name string
@@ -152,7 +403,14 @@ func TestLoadConfigFromFile_InvalidValues(t *testing.T) {
 		{"min_score negative", `[search]` + "\n" + `min_score = -0.1`},
 		{"budget too low", `[context]` + "\n" + `budget_tokens = 100`},
 		{"budget too high", `[context]` + "\n" + `budget_tokens = 99999`},
-		{"invalid backend", `[vector]` + "\n" + `backend = "faiss"`},
+		{"invalid vector backend", `[vector]` + "\n" + `backend = "faiss"`},
+		{"invalid database backend", `[database]` + "\n" + `backend = "mysql"`},
+		{"postgres max_open_conns < 1", `[postgres]` + "\n" + `max_open_conns = 0`},
+		{"postgres max_idle_conns < 0", `[postgres]` + "\n" + `max_idle_conns = -1`},
+		{"embedding dims too high", `[embedding]` + "\n" + `dims = 5000`},
+		{"embedding dims too low", `[embedding]` + "\n" + `dims = 0`},
+		{"embedding batch_size < 1", `[embedding]` + "\n" + `batch_size = 0`},
+		{"embedding invalid timeout", `[embedding]` + "\n" + `timeout = "not-a-duration"`},
 	}
 
 	for _, tt := range tests {
@@ -208,6 +466,25 @@ func TestWriteSampleConfig(t *testing.T) {
 	if !contains(content, "# backend") {
 		t.Error("expected commented backend")
 	}
+	// New sections
+	if !contains(content, "[database]") {
+		t.Error("expected [database] section")
+	}
+	if !contains(content, "[postgres]") {
+		t.Error("expected [postgres] section")
+	}
+	if !contains(content, "[qdrant]") {
+		t.Error("expected [qdrant] section")
+	}
+	if !contains(content, "[embedding]") {
+		t.Error("expected [embedding] section")
+	}
+	if !contains(content, "# connection_string") {
+		t.Error("expected commented connection_string")
+	}
+	if !contains(content, "# ollama_url") {
+		t.Error("expected commented ollama_url")
+	}
 
 	// Loading the sample should produce default config (all commented out)
 	cfg := DefaultConfig(dir)
@@ -239,6 +516,47 @@ func TestWriteSampleConfig_MkdirAllFails(t *testing.T) {
 	// Use a path with a null byte -- os.MkdirAll will fail with EINVAL.
 	// WriteSampleConfig should silently return (log and exit), not panic.
 	WriteSampleConfig("/invalid\x00path")
+}
+
+func TestLoadConfigFromFile_BackwardCompatibility(t *testing.T) {
+	// Old TOML files without new sections should parse without error
+	// and retain default values for new fields.
+	dir := t.TempDir()
+	cfgDir := filepath.Join(dir, ".shaktiman")
+	os.MkdirAll(cfgDir, 0o755)
+
+	oldToml := `[search]
+max_results = 25
+
+[vector]
+backend = "hnsw"
+`
+	os.WriteFile(filepath.Join(cfgDir, "shaktiman.toml"), []byte(oldToml), 0o644)
+
+	cfg := DefaultConfig(dir)
+	loaded, err := LoadConfigFromFile(cfg)
+	if err != nil {
+		t.Fatalf("old TOML should parse without error: %v", err)
+	}
+	if loaded.SearchMaxResults != 25 {
+		t.Errorf("SearchMaxResults = %d, want 25", loaded.SearchMaxResults)
+	}
+	if loaded.VectorBackend != "hnsw" {
+		t.Errorf("VectorBackend = %q, want hnsw", loaded.VectorBackend)
+	}
+	// New fields should retain defaults
+	if loaded.DatabaseBackend != "sqlite" {
+		t.Errorf("DatabaseBackend = %q, want sqlite", loaded.DatabaseBackend)
+	}
+	if loaded.PostgresMaxOpen != 20 {
+		t.Errorf("PostgresMaxOpen = %d, want 20", loaded.PostgresMaxOpen)
+	}
+	if loaded.QdrantCollection != "shaktiman" {
+		t.Errorf("QdrantCollection = %q, want shaktiman", loaded.QdrantCollection)
+	}
+	if loaded.EmbedTimeout != 120*time.Second {
+		t.Errorf("EmbedTimeout = %v, want 120s", loaded.EmbedTimeout)
+	}
 }
 
 func TestLoadConfigFromFile_TestPatterns(t *testing.T) {


### PR DESCRIPTION

Extends Config with pluggable backend configuration (ADR-003 Phase 1):

- [database] section with backend selection (sqlite/postgres)
- [postgres] section with connection_string, pool sizing, schema
- [qdrant] section with url, collection, api_key
- [embedding] section with ollama_url, model, dims, batch_size, timeout
- ValidateBackendConfig() for backend combination checks (pgvector requires postgres, postgres requires connection string, etc.)
- Environment variable overrides: SHAKTIMAN_POSTGRES_URL, SHAKTIMAN_QDRANT_API_KEY
- CLI flags: --db, --vector, --postgres-url, --qdrant-url
- Expanded vector.backend validator to accept qdrant and pgvector
- Updated sampleConfig with all new sections

All new sections are optional with sensible defaults. Existing TOML files parse unchanged (backward compatible).