### PR TITLE
feat(types): add WriterStore, DiffStore, GraphMutator, and other backend interfaces

### DIFF
--- a/internal/core/engine_test.go
+++ b/internal/core/engine_test.go
@@ -939,6 +939,10 @@ func (f *failingVectorStore) Close() error {
 	return nil
 }
 
+func (f *failingVectorStore) Healthy(_ context.Context) bool {
+	return true
+}
+
 func TestSearch_KeywordWithMinScore(t *testing.T) {
 	t.Parallel()
 	engine, store := setupTestEngine(t)

--- a/internal/storage/diff.go
+++ b/internal/storage/diff.go
@@ -7,27 +7,13 @@ import (
 	"math"
 	"strings"
 	"time"
+
+	"github.com/shaktimanai/shaktiman/internal/types"
 )
 
-// DiffLogEntry represents a file-level change record.
-type DiffLogEntry struct {
-	ID           int64
-	FileID       int64
-	Timestamp    string
-	ChangeType   string // add | modify | delete | rename
-	LinesAdded   int
-	LinesRemoved int
-	HashBefore   string
-	HashAfter    string
-}
-
-// DiffSymbolEntry represents a symbol-level change within a diff.
-type DiffSymbolEntry struct {
-	SymbolName string
-	SymbolID   int64  // 0 if unknown
-	ChangeType string // added | modified | removed | signature_changed
-	ChunkID    int64  // 0 if unknown
-}
+// Type aliases for backward compatibility. Canonical definitions are in types/.
+type DiffLogEntry = types.DiffLogEntry
+type DiffSymbolEntry = types.DiffSymbolEntry
 
 // InsertDiffLog records a file-level change within a transaction.
 func (s *Store) InsertDiffLog(ctx context.Context, tx *sql.Tx, entry DiffLogEntry) (int64, error) {
@@ -66,12 +52,8 @@ func (s *Store) InsertDiffSymbols(ctx context.Context, tx *sql.Tx, diffID int64,
 	return nil
 }
 
-// RecentDiffsInput configures a recent diffs query.
-type RecentDiffsInput struct {
-	Since  time.Time
-	FileID int64 // 0 for all files
-	Limit  int   // 0 for no limit
-}
+// Type alias for backward compatibility.
+type RecentDiffsInput = types.RecentDiffsInput
 
 // GetRecentDiffs returns diffs within the given time window.
 func (s *Store) GetRecentDiffs(ctx context.Context, input RecentDiffsInput) ([]DiffLogEntry, error) {

--- a/internal/storage/graph.go
+++ b/internal/storage/graph.go
@@ -243,12 +243,8 @@ func (s *Store) PendingEdgeCallers(ctx context.Context, dstName string) ([]int64
 	return ids, rows.Err()
 }
 
-// PendingEdgeCaller holds a source symbol ID and the edge kind from a pending edge.
-type PendingEdgeCaller struct {
-	SrcSymbolID      int64
-	Kind             string
-	DstQualifiedName string
-}
+// Type alias for backward compatibility.
+type PendingEdgeCaller = types.PendingEdgeCaller
 
 // PendingEdgeCallersWithKind returns src_symbol_id, kind, and dst_qualified_name
 // from pending_edges for a given unresolved destination name. Used by the symbols

--- a/internal/types/diff_types.go
+++ b/internal/types/diff_types.go
@@ -1,0 +1,37 @@
+package types
+
+import "time"
+
+// DiffLogEntry represents a file-level change record.
+type DiffLogEntry struct {
+	ID           int64
+	FileID       int64
+	Timestamp    string
+	ChangeType   string // add | modify | delete | rename
+	LinesAdded   int
+	LinesRemoved int
+	HashBefore   string
+	HashAfter    string
+}
+
+// DiffSymbolEntry represents a symbol-level change within a diff.
+type DiffSymbolEntry struct {
+	SymbolName string
+	SymbolID   int64  // 0 if unknown
+	ChangeType string // added | modified | removed | signature_changed
+	ChunkID    int64  // 0 if unknown
+}
+
+// RecentDiffsInput configures a recent diffs query.
+type RecentDiffsInput struct {
+	Since  time.Time
+	FileID int64 // 0 for all files
+	Limit  int   // 0 for no limit
+}
+
+// PendingEdgeCaller holds a source symbol ID and the edge kind from a pending edge.
+type PendingEdgeCaller struct {
+	SrcSymbolID      int64
+	Kind             string
+	DstQualifiedName string
+}

--- a/internal/types/interfaces.go
+++ b/internal/types/interfaces.go
@@ -93,6 +93,10 @@ type VectorStore interface {
 	Has(ctx context.Context, chunkID int64) (bool, error)
 	Count(ctx context.Context) (int, error)
 	Close() error
+	// Healthy returns true if the store is reachable and operational.
+	// In-process backends (BruteForce, HNSW) always return true.
+	// External backends (Qdrant, pgvector) perform a connectivity check.
+	Healthy(ctx context.Context) bool
 }
 
 // VectorPersister is optionally implemented by vector stores that need
@@ -146,4 +150,79 @@ type EmbedProgress struct {
 	Total    int
 	Skipped  int    // chunks that could not be embedded after retries
 	Warning  string // non-empty during transient issues (e.g., circuit breaker retry)
+}
+
+// TxHandle is an opaque transaction handle. Each backend defines its own
+// concrete type (e.g., *sql.Tx for SQLite, pgx.Tx for Postgres).
+// Methods that participate in transactions accept TxHandle.
+type TxHandle interface {
+	// Unexported marker method prevents external implementations.
+	txHandle()
+}
+
+// DiffStore provides diff log and symbol change tracking.
+type DiffStore interface {
+	InsertDiffLog(ctx context.Context, tx TxHandle, entry DiffLogEntry) (int64, error)
+	InsertDiffSymbols(ctx context.Context, tx TxHandle, diffID int64, symbols []DiffSymbolEntry) error
+	GetRecentDiffs(ctx context.Context, input RecentDiffsInput) ([]DiffLogEntry, error)
+	GetDiffSymbols(ctx context.Context, diffID int64) ([]DiffSymbolEntry, error)
+}
+
+// GraphMutator provides graph write operations (edges, pending edges).
+// Extends the existing read-only Neighbors method on MetadataStore.
+type GraphMutator interface {
+	InsertEdges(ctx context.Context, tx TxHandle, fileID int64, edges []EdgeRecord, symbolIDs map[string]int64, language string) error
+	ResolvePendingEdges(ctx context.Context, tx TxHandle, newSymbolNames []string) error
+	DeleteEdgesByFile(ctx context.Context, tx TxHandle, fileID int64) error
+	PendingEdgeCallers(ctx context.Context, dstName string) ([]int64, error)
+	PendingEdgeCallersWithKind(ctx context.Context, dstName string) ([]PendingEdgeCaller, error)
+}
+
+// EmbeddingReconciler provides embedding state management for crash recovery.
+type EmbeddingReconciler interface {
+	CountChunksEmbedded(ctx context.Context) (int, error)
+	ResetAllEmbeddedFlags(ctx context.Context) error
+	GetEmbeddedChunkIDs(ctx context.Context, afterID int64, limit int) ([]int64, error)
+	ResetEmbeddedFlags(ctx context.Context, chunkIDs []int64) error
+	EmbeddingReadiness(ctx context.Context, vectorCount int) (float64, error)
+}
+
+// StoreLifecycle provides backend-specific startup and bulk-write hooks.
+// Returned as a separate value by the factory — not embedded in WriterStore.
+// SQLite: manages FTS5 triggers and index rebuild.
+// Postgres: nil (generated tsvector columns handle FTS automatically).
+type StoreLifecycle interface {
+	OnStartup(ctx context.Context) error
+	OnBulkWriteBegin(ctx context.Context) error
+	OnBulkWriteEnd(ctx context.Context) error
+}
+
+// MetricsWriter persists MCP tool call metrics.
+type MetricsWriter interface {
+	RecordToolCalls(ctx context.Context, records []ToolCallRecord) error
+}
+
+// ToolCallRecord holds a single MCP tool invocation metric.
+type ToolCallRecord struct {
+	SessionID         string
+	ToolName          string
+	ArgsBytes         int
+	ResponseBytes     int
+	ResponseTokensEst int
+	ResultCount       int
+	DurationMs        int64
+	IsError           bool
+}
+
+// WriterStore is the composite interface required by the daemon's write path.
+// The daemon's writer.go and enrichment.go depend on all of these capabilities.
+// StoreLifecycle is NOT embedded here — it is returned separately by the
+// factory and may be nil (e.g., Postgres needs no lifecycle hooks).
+type WriterStore interface {
+	MetadataStore
+	DiffStore
+	GraphMutator
+	EmbeddingReconciler
+	EmbedSource
+	WithWriteTx(ctx context.Context, fn func(tx TxHandle) error) error
 }

--- a/internal/vector/hnsw.go
+++ b/internal/vector/hnsw.go
@@ -184,6 +184,11 @@ func (s *HNSWStore) Close() error {
 	return nil
 }
 
+// Healthy always returns true for the in-process HNSW store.
+func (s *HNSWStore) Healthy(_ context.Context) bool {
+	return true
+}
+
 // Dim returns the vector dimensionality.
 func (s *HNSWStore) Dim() int {
 	return s.dim

--- a/internal/vector/store.go
+++ b/internal/vector/store.go
@@ -161,6 +161,11 @@ func (s *BruteForceStore) Close() error {
 	return nil
 }
 
+// Healthy always returns true for the in-memory brute-force store.
+func (s *BruteForceStore) Healthy(_ context.Context) bool {
+	return true
+}
+
 // Dim returns the vector dimensionality.
 func (s *BruteForceStore) Dim() int {
 	return s.dim


### PR DESCRIPTION
Defines the interface contracts needed for pluggable storage backends (ADR-003 Phase 2a, tasks 2a.1-2a.3):

New interfaces in internal/types/interfaces.go:
- TxHandle: opaque transaction handle for backend-agnostic transactions
- DiffStore: diff log and symbol change tracking (4 methods)
- GraphMutator: graph write operations for edges (5 methods)
- EmbeddingReconciler: embedding state management for crash recovery (5 methods)
- StoreLifecycle: backend-specific startup/bulk-write hooks (3 methods)
- MetricsWriter: MCP tool call metrics persistence
- WriterStore: composite interface (MetadataStore + DiffStore + GraphMutator + EmbeddingReconciler + EmbedSource + WithWriteTx)
- VectorStore gains Healthy(ctx) bool for external backend health checks

Type moves to internal/types/diff_types.go:
- DiffLogEntry, DiffSymbolEntry, RecentDiffsInput, PendingEdgeCaller moved from storage/ to types/ with type aliases for backward compat