### PR TITLE
test: migrate external tests from store.DB().WithWriteTx to store.Wit…

### DIFF
--- a/internal/core/assembler_test.go
+++ b/internal/core/assembler_test.go
@@ -4,7 +4,6 @@ package core
 
 import (
 	"context"
-	"database/sql"
 	"strings"
 	"testing"
 
@@ -132,12 +131,12 @@ func TestAssemble_StructuralExpansion(t *testing.T) {
 	}
 
 	// Create edge: Caller -> Helper (no connection to Unrelated)
-	err = store.DB().WithWriteTx(func(tx *sql.Tx) error {
+	err = store.WithWriteTx(ctx, func(txh types.TxHandle) error {
 		symMap := map[string]int64{
 			"Caller": symIDs[0],
 			"Helper": symIDs[1],
 		}
-		return store.InsertEdges(ctx, storage.SqliteTxHandle{Tx: tx}, fileID, []types.EdgeRecord{
+		return store.InsertEdges(ctx, txh, fileID, []types.EdgeRecord{
 			{SrcSymbolName: "Caller", DstSymbolName: "Helper", Kind: "calls"},
 		}, symMap, "")
 	})
@@ -251,12 +250,12 @@ func TestStructuralExpand_WithEdges(t *testing.T) {
 	}
 
 	// Edge: Main -> Serve
-	err = store.DB().WithWriteTx(func(tx *sql.Tx) error {
+	err = store.WithWriteTx(ctx, func(txh types.TxHandle) error {
 		symMap := map[string]int64{
 			"Main":  symIDs1[0],
 			"Serve": symIDs2[0],
 		}
-		return store.InsertEdges(ctx, storage.SqliteTxHandle{Tx: tx}, fileID1, []types.EdgeRecord{
+		return store.InsertEdges(ctx, txh, fileID1, []types.EdgeRecord{
 			{SrcSymbolName: "Main", DstSymbolName: "Serve", Kind: "calls"},
 		}, symMap, "")
 	})

--- a/internal/core/ranker_test.go
+++ b/internal/core/ranker_test.go
@@ -4,7 +4,6 @@ package core
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"math"
 	"testing"
@@ -374,12 +373,12 @@ func TestComputeStructuralScores_WithGraphEdges(t *testing.T) {
 	}
 
 	// Insert a direct edge: FuncA -> FuncB
-	err = store.DB().WithWriteTx(func(tx *sql.Tx) error {
+	err = store.WithWriteTx(ctx, func(txh types.TxHandle) error {
 		symMap := map[string]int64{
 			"FuncA": symIDs1[0],
 			"FuncB": symIDs2[0],
 		}
-		return store.InsertEdges(ctx, storage.SqliteTxHandle{Tx: tx}, fileID1, []types.EdgeRecord{
+		return store.InsertEdges(ctx, txh, fileID1, []types.EdgeRecord{
 			{SrcSymbolName: "FuncA", DstSymbolName: "FuncB", Kind: "calls"},
 		}, symMap, "")
 	})

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -1427,7 +1427,8 @@ func setupStoreWithTestFiles(t *testing.T) *storage.Store {
 	if err != nil || len(testSyms) == 0 {
 		t.Fatalf("GetSymbolByName TestNewServer: err=%v, len=%d", err, len(testSyms))
 	}
-	if err := store.DB().WithWriteTx(func(tx *sql.Tx) error {
+	if err := store.WithWriteTx(ctx, func(txh types.TxHandle) error {
+		tx := txh.(storage.SqliteTxHandle).Tx
 		_, err := tx.ExecContext(ctx,
 			"INSERT INTO edges (src_symbol_id, dst_symbol_id, kind, file_id) VALUES (?, ?, 'calls', ?)",
 			testSyms[0].ID, implSyms[0].ID, testID)


### PR DESCRIPTION
…hWriteTx

Updates test files in core/ and mcp/ to use the WriterStore interface path (store.WithWriteTx with TxHandle) instead of the concrete store.DB().WithWriteTx(*sql.Tx) path:

- assembler_test.go: 2 edge insertion sites → store.WithWriteTx + txh
- ranker_test.go: 1 edge insertion site → store.WithWriteTx + txh
- tools_test.go: 1 raw SQL edge insertion → store.WithWriteTx + txh

Removes unused "database/sql" imports from assembler_test.go and ranker_test.go. No store.DB().WithWriteTx calls remain outside internal/storage/.