### PR TITLE
feat(storage): add provider registry, migrate daemon + CLI to use it

### DIFF
--- a/cmd/shaktiman/main.go
+++ b/cmd/shaktiman/main.go
@@ -15,7 +15,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/shaktimanai/shaktiman/internal/daemon"
-	"github.com/shaktimanai/shaktiman/internal/storage"
 	"github.com/shaktimanai/shaktiman/internal/types"
 )
 
@@ -245,13 +244,11 @@ func statusCmd() *cobra.Command {
 			projectRoot := args[0]
 			cfg := types.DefaultConfig(projectRoot)
 
-			db, err := storage.Open(storage.OpenInput{Path: cfg.DBPath})
+			store, closer, err := openStore(cfg)
 			if err != nil {
-				return fmt.Errorf("open db: %w", err)
+				return fmt.Errorf("open store: %w", err)
 			}
-			defer db.Close()
-
-			store := storage.NewStore(db)
+			defer closer()
 			ctx := context.Background()
 
 			stats, err := store.GetIndexStats(ctx)

--- a/cmd/shaktiman/query.go
+++ b/cmd/shaktiman/query.go
@@ -15,6 +15,19 @@ import (
 	"github.com/shaktimanai/shaktiman/internal/types"
 )
 
+// openStore creates a WriterStore using the registry for the given config.
+// The returned closer must be deferred by the caller.
+func openStore(cfg types.Config) (types.WriterStore, func() error, error) {
+	store, _, closer, err := storage.NewMetadataStore(storage.MetadataStoreConfig{
+		Backend:    cfg.DatabaseBackend,
+		SQLitePath: cfg.DBPath,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	return store, closer, nil
+}
+
 func searchCmd() *cobra.Command {
 	var (
 		root       string
@@ -35,13 +48,11 @@ func searchCmd() *cobra.Command {
 				return fmt.Errorf("load config: %w", err)
 			}
 
-			db, err := storage.Open(storage.OpenInput{Path: cfg.DBPath})
+			store, closer, err := openStore(cfg)
 			if err != nil {
-				return fmt.Errorf("open db: %w", err)
+				return fmt.Errorf("open store: %w", err)
 			}
-			defer db.Close()
-
-			store := storage.NewStore(db)
+			defer closer()
 			engine := core.NewQueryEngine(store, root)
 
 			if maxResults == 0 {
@@ -129,13 +140,11 @@ func contextCmd() *cobra.Command {
 				return fmt.Errorf("load config: %w", err)
 			}
 
-			db, err := storage.Open(storage.OpenInput{Path: cfg.DBPath})
+			store, closer, err := openStore(cfg)
 			if err != nil {
-				return fmt.Errorf("open db: %w", err)
+				return fmt.Errorf("open store: %w", err)
 			}
-			defer db.Close()
-
-			store := storage.NewStore(db)
+			defer closer()
 			engine := core.NewQueryEngine(store, root)
 
 			if budget == 0 {
@@ -184,13 +193,11 @@ func symbolsCmd() *cobra.Command {
 				return fmt.Errorf("load config: %w", err)
 			}
 
-			db, err := storage.Open(storage.OpenInput{Path: cfg.DBPath})
+			store, closer, err := openStore(cfg)
 			if err != nil {
-				return fmt.Errorf("open db: %w", err)
+				return fmt.Errorf("open store: %w", err)
 			}
-			defer db.Close()
-
-			store := storage.NewStore(db)
+			defer closer()
 			ctx := context.Background()
 
 			syms, err := store.GetSymbolByName(ctx, args[0])
@@ -249,13 +256,11 @@ func depsCmd() *cobra.Command {
 				return fmt.Errorf("load config: %w", err)
 			}
 
-			db, err := storage.Open(storage.OpenInput{Path: cfg.DBPath})
+			store, closer, err := openStore(cfg)
 			if err != nil {
-				return fmt.Errorf("open db: %w", err)
+				return fmt.Errorf("open store: %w", err)
 			}
-			defer db.Close()
-
-			store := storage.NewStore(db)
+			defer closer()
 			ctx := context.Background()
 
 			dir := direction
@@ -335,13 +340,11 @@ func diffCmd() *cobra.Command {
 				return fmt.Errorf("load config: %w", err)
 			}
 
-			db, err := storage.Open(storage.OpenInput{Path: cfg.DBPath})
+			store, closer, err := openStore(cfg)
 			if err != nil {
-				return fmt.Errorf("open db: %w", err)
+				return fmt.Errorf("open store: %w", err)
 			}
-			defer db.Close()
-
-			store := storage.NewStore(db)
+			defer closer()
 			ctx := context.Background()
 
 			duration, err := time.ParseDuration(since)
@@ -353,7 +356,7 @@ func diffCmd() *cobra.Command {
 			}
 
 			sinceTime := time.Now().Add(-duration)
-			diffs, err := store.GetRecentDiffs(ctx, storage.RecentDiffsInput{
+			diffs, err := store.GetRecentDiffs(ctx, types.RecentDiffsInput{
 				Since: sinceTime,
 				Limit: limit,
 			})
@@ -410,13 +413,11 @@ func enrichmentStatusCmd() *cobra.Command {
 				return fmt.Errorf("load config: %w", err)
 			}
 
-			db, err := storage.Open(storage.OpenInput{Path: cfg.DBPath})
+			store, closer, err := openStore(cfg)
 			if err != nil {
-				return fmt.Errorf("open db: %w", err)
+				return fmt.Errorf("open store: %w", err)
 			}
-			defer db.Close()
-
-			store := storage.NewStore(db)
+			defer closer()
 			stats, err := store.GetIndexStats(context.Background())
 			if err != nil {
 				return fmt.Errorf("stats: %w", err)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -22,7 +22,7 @@ import (
 // Daemon manages the lifecycle of the Shaktiman indexing system.
 type Daemon struct {
 	cfg              types.Config
-	db               *storage.DB              // retained for Close() and metrics; not exposed
+	dbCloser         func() error             // closes the underlying database
 	store            types.WriterStore
 	lifecycle        types.StoreLifecycle     // nil if backend needs no lifecycle hooks
 	writer           *WriterManager
@@ -43,20 +43,15 @@ type Daemon struct {
 
 // New creates a new Daemon, opening the database and running migrations.
 func New(cfg types.Config) (*Daemon, error) {
-	db, err := storage.Open(storage.OpenInput{Path: cfg.DBPath})
+	store, lifecycle, dbCloser, err := storage.NewMetadataStore(storage.MetadataStoreConfig{
+		Backend:    cfg.DatabaseBackend,
+		SQLitePath: cfg.DBPath,
+	})
 	if err != nil {
-		return nil, fmt.Errorf("open database: %w", err)
+		return nil, fmt.Errorf("create metadata store: %w", err)
 	}
 
-	if err := storage.Migrate(db); err != nil {
-		db.Close()
-		return nil, fmt.Errorf("run migrations: %w", err)
-	}
-
-	concreteStore := storage.NewStore(db)
-	var store types.WriterStore = concreteStore
-	lifecycle := storage.NewSQLiteLifecycle(concreteStore)
-	engine := core.NewQueryEngine(concreteStore, cfg.ProjectRoot)
+	engine := core.NewQueryEngine(store, cfg.ProjectRoot)
 	writer := NewWriterManager(store, cfg.WriterChannelSize, cfg.TestPatterns)
 
 	// Session-aware ranking
@@ -65,7 +60,7 @@ func New(cfg types.Config) (*Daemon, error) {
 
 	d := &Daemon{
 		cfg:       cfg,
-		db:        db,
+		dbCloser:  dbCloser,
 		store:     store,
 		lifecycle: lifecycle,
 		writer:    writer,
@@ -184,15 +179,22 @@ func (d *Daemon) Start(ctx context.Context) error {
 		}
 	}()
 
-	// Start metrics recorder
-	recorder := mcp.NewMetricsRecorder(mcp.MetricsRecorderInput{
-		DB:        d.db.Writer(),
-		SessionID: d.sessionID,
-		Logger:    d.logger.With("component", "metrics"),
-	})
-	metricsCtx, metricsCancel := context.WithCancel(ctx)
-	defer metricsCancel()
-	go recorder.Run(metricsCtx)
+	// Start metrics recorder.
+	// MetricsRecorder needs raw *sql.DB — access via concrete Store.DB().Writer().
+	// This will be replaced with a MetricsWriter interface in a future PR.
+	var recorder *mcp.MetricsRecorder
+	if sqliteStore, ok := d.store.(*storage.Store); ok {
+		recorder = mcp.NewMetricsRecorder(mcp.MetricsRecorderInput{
+			DB:        sqliteStore.DB().Writer(),
+			SessionID: d.sessionID,
+			Logger:    d.logger.With("component", "metrics"),
+		})
+	}
+	if recorder != nil {
+		metricsCtx, metricsCancel := context.WithCancel(ctx)
+		defer metricsCancel()
+		go recorder.Run(metricsCtx)
+	}
 
 	// Start MCP server (blocks on stdio)
 	s := mcp.NewServer(mcp.NewServerInput{
@@ -426,8 +428,10 @@ func (d *Daemon) Stop() error {
 	}
 
 	// Close database
-	if err := d.db.Close(); err != nil {
-		return fmt.Errorf("close database: %w", err)
+	if d.dbCloser != nil {
+		if err := d.dbCloser(); err != nil {
+			return fmt.Errorf("close database: %w", err)
+		}
 	}
 
 	d.logger.Info("shutdown complete", "duration_ms", time.Since(start).Milliseconds())

--- a/internal/storage/register.go
+++ b/internal/storage/register.go
@@ -1,0 +1,30 @@
+package storage
+
+import "github.com/shaktimanai/shaktiman/internal/types"
+
+// init registers the SQLite backend with the provider registry.
+// This is called automatically when the storage package is imported.
+// Future backends (postgres) will register from their own sub-packages.
+func init() {
+	RegisterMetadataStore("sqlite", func(cfg MetadataStoreConfig) (types.WriterStore, types.StoreLifecycle, func() error, error) {
+		input := OpenInput{
+			Path:     cfg.SQLitePath,
+			InMemory: cfg.SQLiteInMemory,
+		}
+		db, err := Open(input)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+
+		if err := Migrate(db); err != nil {
+			db.Close()
+			return nil, nil, nil, err
+		}
+
+		store := NewStore(db)
+		lifecycle := NewSQLiteLifecycle(store)
+		closer := func() error { return db.Close() }
+
+		return store, lifecycle, closer, nil
+	})
+}

--- a/internal/storage/registry.go
+++ b/internal/storage/registry.go
@@ -1,0 +1,58 @@
+// Package storage provides the provider registry for MetadataStore backends.
+// Each backend (sqlite, postgres) registers a factory via init().
+// The daemon calls NewMetadataStore(cfg) to create the configured backend.
+package storage
+
+import (
+	"fmt"
+
+	"github.com/shaktimanai/shaktiman/internal/types"
+)
+
+// MetadataStoreConfig holds backend-agnostic configuration for creating a MetadataStore.
+type MetadataStoreConfig struct {
+	Backend        string // "sqlite" or "postgres"
+	SQLitePath     string // file path for SQLite database
+	SQLiteInMemory bool   // use in-memory database (for tests)
+
+	PostgresConnStr string
+	PostgresMaxOpen int
+	PostgresMaxIdle int
+	PostgresSchema  string
+}
+
+// MetadataStoreFactory creates a WriterStore from config.
+// Returns the store, an optional StoreLifecycle (nil if backend needs none),
+// a closer function, and any error.
+type MetadataStoreFactory func(cfg MetadataStoreConfig) (types.WriterStore, types.StoreLifecycle, func() error, error)
+
+var metadataStoreFactories = map[string]MetadataStoreFactory{}
+
+// RegisterMetadataStore registers a factory for a named backend.
+// Called from init() in each backend sub-package.
+func RegisterMetadataStore(name string, factory MetadataStoreFactory) {
+	metadataStoreFactories[name] = factory
+}
+
+// NewMetadataStore creates a WriterStore for the configured backend.
+// Returns the store, an optional lifecycle, a closer function, and any error.
+func NewMetadataStore(cfg MetadataStoreConfig) (types.WriterStore, types.StoreLifecycle, func() error, error) {
+	if cfg.Backend == "" {
+		cfg.Backend = "sqlite"
+	}
+	factory, ok := metadataStoreFactories[cfg.Backend]
+	if !ok {
+		available := make([]string, 0, len(metadataStoreFactories))
+		for name := range metadataStoreFactories {
+			available = append(available, name)
+		}
+		return nil, nil, nil, fmt.Errorf("unknown metadata store backend: %q (available: %v)", cfg.Backend, available)
+	}
+	return factory(cfg)
+}
+
+// HasMetadataStore returns true if a factory is registered for the named backend.
+func HasMetadataStore(name string) bool {
+	_, ok := metadataStoreFactories[name]
+	return ok
+}

--- a/internal/storage/registry_test.go
+++ b/internal/storage/registry_test.go
@@ -1,0 +1,132 @@
+package storage
+
+import (
+	"context"
+	"testing"
+
+	"github.com/shaktimanai/shaktiman/internal/types"
+)
+
+func TestNewMetadataStore_SQLite(t *testing.T) {
+	t.Parallel()
+
+	store, lifecycle, closer, err := NewMetadataStore(MetadataStoreConfig{
+		Backend:        "sqlite",
+		SQLiteInMemory: true,
+	})
+	if err != nil {
+		t.Fatalf("NewMetadataStore: %v", err)
+	}
+	defer closer()
+
+	if store == nil {
+		t.Fatal("expected non-nil store")
+	}
+	if lifecycle == nil {
+		t.Fatal("expected non-nil lifecycle for SQLite")
+	}
+
+	// Verify the store is functional
+	ctx := context.Background()
+	_, err = store.UpsertFile(ctx, &types.FileRecord{
+		Path: "test.go", ContentHash: "h1", Mtime: 1.0,
+		Language: "go", EmbeddingStatus: "pending", ParseQuality: "full",
+	})
+	if err != nil {
+		t.Fatalf("UpsertFile: %v", err)
+	}
+
+	f, err := store.GetFileByPath(ctx, "test.go")
+	if err != nil {
+		t.Fatalf("GetFileByPath: %v", err)
+	}
+	if f == nil || f.ContentHash != "h1" {
+		t.Errorf("unexpected file: %+v", f)
+	}
+}
+
+func TestNewMetadataStore_SQLiteWithLifecycle(t *testing.T) {
+	t.Parallel()
+
+	store, lifecycle, closer, err := NewMetadataStore(MetadataStoreConfig{
+		Backend:        "sqlite",
+		SQLiteInMemory: true,
+	})
+	if err != nil {
+		t.Fatalf("NewMetadataStore: %v", err)
+	}
+	defer closer()
+
+	ctx := context.Background()
+
+	// Lifecycle hooks should work
+	if err := lifecycle.OnStartup(ctx); err != nil {
+		t.Fatalf("OnStartup: %v", err)
+	}
+	if err := lifecycle.OnBulkWriteBegin(ctx); err != nil {
+		t.Fatalf("OnBulkWriteBegin: %v", err)
+	}
+
+	// Insert during bulk mode
+	store.UpsertFile(ctx, &types.FileRecord{
+		Path: "bulk.go", ContentHash: "h1", Mtime: 1.0,
+		Language: "go", EmbeddingStatus: "pending", ParseQuality: "full",
+	})
+	store.InsertChunks(ctx, 1, []types.ChunkRecord{
+		{ChunkIndex: 0, Kind: "function", SymbolName: "BulkFunc",
+			StartLine: 1, EndLine: 5, Content: "func BulkFunc() {}", TokenCount: 3},
+	})
+
+	if err := lifecycle.OnBulkWriteEnd(ctx); err != nil {
+		t.Fatalf("OnBulkWriteEnd: %v", err)
+	}
+
+	// FTS should work after lifecycle cycle
+	results, err := store.KeywordSearch(ctx, "BulkFunc", 10)
+	if err != nil {
+		t.Fatalf("KeywordSearch: %v", err)
+	}
+	if len(results) == 0 {
+		t.Error("expected FTS results after lifecycle bulk write cycle")
+	}
+}
+
+func TestNewMetadataStore_UnknownBackend(t *testing.T) {
+	t.Parallel()
+
+	_, _, _, err := NewMetadataStore(MetadataStoreConfig{
+		Backend: "mysql",
+	})
+	if err == nil {
+		t.Fatal("expected error for unknown backend")
+	}
+}
+
+func TestHasMetadataStore(t *testing.T) {
+	if !HasMetadataStore("sqlite") {
+		t.Error("expected SQLite to be registered")
+	}
+	if HasMetadataStore("postgres") {
+		t.Error("expected postgres to NOT be registered yet")
+	}
+	if HasMetadataStore("nonexistent") {
+		t.Error("expected nonexistent to NOT be registered")
+	}
+}
+
+func TestNewMetadataStore_CloserWorks(t *testing.T) {
+	t.Parallel()
+
+	_, _, closer, err := NewMetadataStore(MetadataStoreConfig{
+		Backend:        "sqlite",
+		SQLiteInMemory: true,
+	})
+	if err != nil {
+		t.Fatalf("NewMetadataStore: %v", err)
+	}
+
+	// Closer should not error
+	if err := closer(); err != nil {
+		t.Fatalf("closer: %v", err)
+	}
+}


### PR DESCRIPTION
Implements the provider pattern for pluggable storage backends (ADR-003 Phase 2b):

Registry (internal/storage/registry.go):
- MetadataStoreConfig: backend-agnostic config struct
- RegisterMetadataStore: factory registration (called from init())
- NewMetadataStore: creates WriterStore + StoreLifecycle from config
- HasMetadataStore: checks if a backend is registered
- Defaults to "sqlite" when backend is empty

SQLite registration (internal/storage/register.go):
- init() registers "sqlite" factory: Open → Migrate → NewStore → lifecycle

Daemon (internal/daemon/daemon.go):
- New() uses storage.NewMetadataStore(cfg) instead of direct storage.Open() + Migrate() + NewStore()
- db field replaced with dbCloser func() error
- MetricsRecorder created via type assertion to *storage.Store (documented as temporary — will be replaced with MetricsWriter)

CLI (cmd/shaktiman/):
- New openStore() helper using registry
- All 7 storage.Open() + NewStore() call sites replaced
- Removed direct storage import from main.go

Tests (internal/storage/registry_test.go):
- TestNewMetadataStore_SQLite: functional roundtrip
- TestNewMetadataStore_SQLiteWithLifecycle: lifecycle hooks + FTS
- TestNewMetadataStore_UnknownBackend: error for unregistered backend
- TestHasMetadataStore: registration check
- TestNewMetadataStore_CloserWorks: closer doesn't error