### PR TITLE
test: add shared compliance suites for MetadataStore and VectorStore

### DIFF
--- a/internal/storage/storetest/sqlite_compliance_test.go
+++ b/internal/storage/storetest/sqlite_compliance_test.go
@@ -1,0 +1,25 @@
+//go:build sqlite_fts5
+
+package storetest
+
+import (
+	"testing"
+
+	"github.com/shaktimanai/shaktiman/internal/storage"
+	"github.com/shaktimanai/shaktiman/internal/types"
+)
+
+func TestSQLiteMetadataStoreCompliance(t *testing.T) {
+	RunMetadataStoreTests(t, func(t *testing.T) types.MetadataStore {
+		t.Helper()
+		db, err := storage.Open(storage.OpenInput{InMemory: true})
+		if err != nil {
+			t.Fatalf("Open: %v", err)
+		}
+		if err := storage.Migrate(db); err != nil {
+			t.Fatalf("Migrate: %v", err)
+		}
+		t.Cleanup(func() { db.Close() })
+		return storage.NewStore(db)
+	})
+}

--- a/internal/storage/storetest/suite.go
+++ b/internal/storage/storetest/suite.go
@@ -1,0 +1,378 @@
+// Package storetest provides compliance test suites for MetadataStore
+// and WriterStore implementations. Any backend (SQLite, Postgres) must
+// pass these tests to be considered a valid implementation.
+package storetest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/shaktimanai/shaktiman/internal/types"
+)
+
+// MetadataStoreFactory creates a fresh MetadataStore for each test.
+// The store should be empty (freshly migrated).
+type MetadataStoreFactory func(t *testing.T) types.MetadataStore
+
+// RunMetadataStoreTests runs the full compliance suite against a MetadataStore.
+func RunMetadataStoreTests(t *testing.T, factory MetadataStoreFactory) {
+	t.Run("UpsertFile_Insert", func(t *testing.T) {
+		store := factory(t)
+		ctx := context.Background()
+
+		id, err := store.UpsertFile(ctx, &types.FileRecord{
+			Path: "main.go", ContentHash: "h1", Mtime: 1.0,
+			Language: "go", EmbeddingStatus: "pending", ParseQuality: "full",
+		})
+		if err != nil {
+			t.Fatalf("UpsertFile: %v", err)
+		}
+		if id == 0 {
+			t.Error("expected non-zero file ID")
+		}
+	})
+
+	t.Run("UpsertFile_Update", func(t *testing.T) {
+		store := factory(t)
+		ctx := context.Background()
+
+		id1, _ := store.UpsertFile(ctx, &types.FileRecord{
+			Path: "main.go", ContentHash: "h1", Mtime: 1.0,
+			Language: "go", EmbeddingStatus: "pending", ParseQuality: "full",
+		})
+		id2, _ := store.UpsertFile(ctx, &types.FileRecord{
+			Path: "main.go", ContentHash: "h2", Mtime: 2.0,
+			Language: "go", EmbeddingStatus: "pending", ParseQuality: "full",
+		})
+		if id1 != id2 {
+			t.Errorf("upsert should return same ID: got %d and %d", id1, id2)
+		}
+		f, _ := store.GetFileByPath(ctx, "main.go")
+		if f.ContentHash != "h2" {
+			t.Errorf("ContentHash = %q, want h2", f.ContentHash)
+		}
+	})
+
+	t.Run("GetFileByPath_NotFound", func(t *testing.T) {
+		store := factory(t)
+		f, err := store.GetFileByPath(context.Background(), "nonexistent.go")
+		if err == nil && f != nil {
+			t.Error("expected nil or error for nonexistent file")
+		}
+	})
+
+	t.Run("ListFiles", func(t *testing.T) {
+		store := factory(t)
+		ctx := context.Background()
+
+		store.UpsertFile(ctx, &types.FileRecord{
+			Path: "a.go", ContentHash: "h1", Mtime: 1.0,
+			Language: "go", EmbeddingStatus: "pending", ParseQuality: "full",
+		})
+		store.UpsertFile(ctx, &types.FileRecord{
+			Path: "b.go", ContentHash: "h2", Mtime: 1.0,
+			Language: "go", EmbeddingStatus: "pending", ParseQuality: "full",
+		})
+
+		files, err := store.ListFiles(ctx)
+		if err != nil {
+			t.Fatalf("ListFiles: %v", err)
+		}
+		if len(files) != 2 {
+			t.Errorf("ListFiles: got %d, want 2", len(files))
+		}
+	})
+
+	t.Run("DeleteFile_Cascades", func(t *testing.T) {
+		store := factory(t)
+		ctx := context.Background()
+
+		fileID, _ := store.UpsertFile(ctx, &types.FileRecord{
+			Path: "del.go", ContentHash: "h1", Mtime: 1.0,
+			Language: "go", EmbeddingStatus: "pending", ParseQuality: "full",
+		})
+		store.InsertChunks(ctx, fileID, []types.ChunkRecord{
+			{ChunkIndex: 0, Kind: "function", SymbolName: "Foo",
+				StartLine: 1, EndLine: 5, Content: "func Foo() {}", TokenCount: 3},
+		})
+
+		if err := store.DeleteFile(ctx, fileID); err != nil {
+			t.Fatalf("DeleteFile: %v", err)
+		}
+		chunks, _ := store.GetChunksByFile(ctx, fileID)
+		if len(chunks) != 0 {
+			t.Error("expected chunks to be cascade-deleted")
+		}
+	})
+
+	t.Run("InsertChunks_And_GetByFile", func(t *testing.T) {
+		store := factory(t)
+		ctx := context.Background()
+
+		fileID, _ := store.UpsertFile(ctx, &types.FileRecord{
+			Path: "chunks.go", ContentHash: "h1", Mtime: 1.0,
+			Language: "go", EmbeddingStatus: "pending", ParseQuality: "full",
+		})
+		ids, err := store.InsertChunks(ctx, fileID, []types.ChunkRecord{
+			{ChunkIndex: 0, Kind: "function", SymbolName: "A",
+				StartLine: 1, EndLine: 5, Content: "func A() {}", TokenCount: 3},
+			{ChunkIndex: 1, Kind: "function", SymbolName: "B",
+				StartLine: 6, EndLine: 10, Content: "func B() {}", TokenCount: 3},
+		})
+		if err != nil {
+			t.Fatalf("InsertChunks: %v", err)
+		}
+		if len(ids) != 2 {
+			t.Fatalf("expected 2 chunk IDs, got %d", len(ids))
+		}
+
+		chunks, err := store.GetChunksByFile(ctx, fileID)
+		if err != nil {
+			t.Fatalf("GetChunksByFile: %v", err)
+		}
+		if len(chunks) != 2 {
+			t.Errorf("GetChunksByFile: got %d, want 2", len(chunks))
+		}
+		if chunks[0].SymbolName != "A" || chunks[1].SymbolName != "B" {
+			t.Errorf("chunks not ordered by index: %v", chunks)
+		}
+	})
+
+	t.Run("GetChunkByID", func(t *testing.T) {
+		store := factory(t)
+		ctx := context.Background()
+
+		fileID, _ := store.UpsertFile(ctx, &types.FileRecord{
+			Path: "c.go", ContentHash: "h1", Mtime: 1.0,
+			Language: "go", EmbeddingStatus: "pending", ParseQuality: "full",
+		})
+		ids, _ := store.InsertChunks(ctx, fileID, []types.ChunkRecord{
+			{ChunkIndex: 0, Kind: "function", SymbolName: "X",
+				StartLine: 1, EndLine: 5, Content: "func X() {}", TokenCount: 3},
+		})
+
+		chunk, err := store.GetChunkByID(ctx, ids[0])
+		if err != nil {
+			t.Fatalf("GetChunkByID: %v", err)
+		}
+		if chunk.SymbolName != "X" {
+			t.Errorf("SymbolName = %q, want X", chunk.SymbolName)
+		}
+	})
+
+	t.Run("InsertSymbols_And_GetByName", func(t *testing.T) {
+		store := factory(t)
+		ctx := context.Background()
+
+		fileID, _ := store.UpsertFile(ctx, &types.FileRecord{
+			Path: "sym.go", ContentHash: "h1", Mtime: 1.0,
+			Language: "go", EmbeddingStatus: "pending", ParseQuality: "full",
+		})
+		chunkIDs, _ := store.InsertChunks(ctx, fileID, []types.ChunkRecord{
+			{ChunkIndex: 0, Kind: "function", SymbolName: "MyFunc",
+				StartLine: 1, EndLine: 5, Content: "func MyFunc() {}", TokenCount: 3},
+		})
+		symIDs, err := store.InsertSymbols(ctx, fileID, []types.SymbolRecord{
+			{ChunkID: chunkIDs[0], Name: "MyFunc", Kind: "function", Line: 1,
+				Visibility: "exported", IsExported: true},
+		})
+		if err != nil {
+			t.Fatalf("InsertSymbols: %v", err)
+		}
+		if len(symIDs) != 1 {
+			t.Fatalf("expected 1 symbol ID, got %d", len(symIDs))
+		}
+
+		syms, err := store.GetSymbolByName(ctx, "MyFunc")
+		if err != nil {
+			t.Fatalf("GetSymbolByName: %v", err)
+		}
+		if len(syms) != 1 || syms[0].Name != "MyFunc" {
+			t.Errorf("unexpected symbols: %+v", syms)
+		}
+	})
+
+	t.Run("GetSymbolByID", func(t *testing.T) {
+		store := factory(t)
+		ctx := context.Background()
+
+		fileID, _ := store.UpsertFile(ctx, &types.FileRecord{
+			Path: "sid.go", ContentHash: "h1", Mtime: 1.0,
+			Language: "go", EmbeddingStatus: "pending", ParseQuality: "full",
+		})
+		chunkIDs, err := store.InsertChunks(ctx, fileID, []types.ChunkRecord{
+			{ChunkIndex: 0, Kind: "function", SymbolName: "Fn",
+				StartLine: 1, EndLine: 5, Content: "func Fn() {}", TokenCount: 3},
+		})
+		if err != nil {
+			t.Fatalf("InsertChunks: %v", err)
+		}
+		symIDs, err := store.InsertSymbols(ctx, fileID, []types.SymbolRecord{
+			{ChunkID: chunkIDs[0], Name: "Fn", Kind: "function", Line: 1, Visibility: "exported"},
+		})
+		if err != nil {
+			t.Fatalf("InsertSymbols: %v", err)
+		}
+		if len(symIDs) == 0 {
+			t.Fatal("InsertSymbols returned no IDs")
+		}
+
+		sym, err := store.GetSymbolByID(ctx, symIDs[0])
+		if err != nil {
+			t.Fatalf("GetSymbolByID: %v", err)
+		}
+		if sym == nil || sym.Name != "Fn" {
+			t.Errorf("unexpected symbol: %+v", sym)
+		}
+	})
+
+	t.Run("GetFilePathByID", func(t *testing.T) {
+		store := factory(t)
+		ctx := context.Background()
+
+		fileID, _ := store.UpsertFile(ctx, &types.FileRecord{
+			Path: "path/to/file.go", ContentHash: "h1", Mtime: 1.0,
+			Language: "go", EmbeddingStatus: "pending", ParseQuality: "full",
+		})
+		path, err := store.GetFilePathByID(ctx, fileID)
+		if err != nil {
+			t.Fatalf("GetFilePathByID: %v", err)
+		}
+		if path != "path/to/file.go" {
+			t.Errorf("path = %q, want path/to/file.go", path)
+		}
+	})
+
+	t.Run("GetFileIsTestByID", func(t *testing.T) {
+		store := factory(t)
+		ctx := context.Background()
+
+		testID, _ := store.UpsertFile(ctx, &types.FileRecord{
+			Path: "x_test.go", ContentHash: "h1", Mtime: 1.0,
+			Language: "go", EmbeddingStatus: "pending", ParseQuality: "full",
+			IsTest: true,
+		})
+		implID, _ := store.UpsertFile(ctx, &types.FileRecord{
+			Path: "x.go", ContentHash: "h2", Mtime: 1.0,
+			Language: "go", EmbeddingStatus: "pending", ParseQuality: "full",
+			IsTest: false,
+		})
+
+		isTest, _ := store.GetFileIsTestByID(ctx, testID)
+		if !isTest {
+			t.Error("expected true for test file")
+		}
+		isTest, _ = store.GetFileIsTestByID(ctx, implID)
+		if isTest {
+			t.Error("expected false for impl file")
+		}
+	})
+
+	t.Run("GetIndexStats", func(t *testing.T) {
+		store := factory(t)
+		ctx := context.Background()
+
+		fileID, _ := store.UpsertFile(ctx, &types.FileRecord{
+			Path: "stats.go", ContentHash: "h1", Mtime: 1.0,
+			Language: "go", EmbeddingStatus: "pending", ParseQuality: "full",
+		})
+		store.InsertChunks(ctx, fileID, []types.ChunkRecord{
+			{ChunkIndex: 0, Kind: "function", SymbolName: "F",
+				StartLine: 1, EndLine: 5, Content: "func F() {}", TokenCount: 3},
+		})
+		store.InsertSymbols(ctx, fileID, []types.SymbolRecord{
+			{ChunkID: 1, Name: "F", Kind: "function", Line: 1, Visibility: "exported"},
+		})
+
+		stats, err := store.GetIndexStats(ctx)
+		if err != nil {
+			t.Fatalf("GetIndexStats: %v", err)
+		}
+		if stats.TotalFiles != 1 {
+			t.Errorf("TotalFiles = %d, want 1", stats.TotalFiles)
+		}
+		if stats.TotalChunks != 1 {
+			t.Errorf("TotalChunks = %d, want 1", stats.TotalChunks)
+		}
+	})
+
+	t.Run("KeywordSearch", func(t *testing.T) {
+		store := factory(t)
+		ctx := context.Background()
+
+		fileID, _ := store.UpsertFile(ctx, &types.FileRecord{
+			Path: "search.go", ContentHash: "h1", Mtime: 1.0,
+			Language: "go", EmbeddingStatus: "pending", ParseQuality: "full",
+		})
+		store.InsertChunks(ctx, fileID, []types.ChunkRecord{
+			{ChunkIndex: 0, Kind: "function", SymbolName: "HandleRequest",
+				StartLine: 1, EndLine: 10, Content: "func HandleRequest(w http.ResponseWriter, r *http.Request) {}", TokenCount: 15},
+		})
+
+		results, err := store.KeywordSearch(ctx, "HandleRequest", 10)
+		if err != nil {
+			t.Fatalf("KeywordSearch: %v", err)
+		}
+		if len(results) == 0 {
+			t.Error("expected at least 1 FTS result")
+		}
+	})
+
+	t.Run("KeywordSearch_Empty", func(t *testing.T) {
+		store := factory(t)
+		results, err := store.KeywordSearch(context.Background(), "", 10)
+		if err != nil {
+			t.Fatalf("KeywordSearch empty: %v", err)
+		}
+		if results != nil {
+			t.Errorf("expected nil for empty query, got %d results", len(results))
+		}
+	})
+
+	t.Run("DeleteChunksByFile", func(t *testing.T) {
+		store := factory(t)
+		ctx := context.Background()
+
+		fileID, _ := store.UpsertFile(ctx, &types.FileRecord{
+			Path: "dc.go", ContentHash: "h1", Mtime: 1.0,
+			Language: "go", EmbeddingStatus: "pending", ParseQuality: "full",
+		})
+		store.InsertChunks(ctx, fileID, []types.ChunkRecord{
+			{ChunkIndex: 0, Kind: "function", SymbolName: "Del",
+				StartLine: 1, EndLine: 5, Content: "func Del() {}", TokenCount: 3},
+		})
+
+		if err := store.DeleteChunksByFile(ctx, fileID); err != nil {
+			t.Fatalf("DeleteChunksByFile: %v", err)
+		}
+		chunks, _ := store.GetChunksByFile(ctx, fileID)
+		if len(chunks) != 0 {
+			t.Error("expected 0 chunks after delete")
+		}
+	})
+
+	t.Run("DeleteSymbolsByFile", func(t *testing.T) {
+		store := factory(t)
+		ctx := context.Background()
+
+		fileID, _ := store.UpsertFile(ctx, &types.FileRecord{
+			Path: "ds.go", ContentHash: "h1", Mtime: 1.0,
+			Language: "go", EmbeddingStatus: "pending", ParseQuality: "full",
+		})
+		chunkIDs, _ := store.InsertChunks(ctx, fileID, []types.ChunkRecord{
+			{ChunkIndex: 0, Kind: "function", SymbolName: "S",
+				StartLine: 1, EndLine: 5, Content: "func S() {}", TokenCount: 3},
+		})
+		store.InsertSymbols(ctx, fileID, []types.SymbolRecord{
+			{ChunkID: chunkIDs[0], Name: "S", Kind: "function", Line: 1, Visibility: "exported"},
+		})
+
+		if err := store.DeleteSymbolsByFile(ctx, fileID); err != nil {
+			t.Fatalf("DeleteSymbolsByFile: %v", err)
+		}
+		syms, _ := store.GetSymbolsByFile(ctx, fileID)
+		if len(syms) != 0 {
+			t.Error("expected 0 symbols after delete")
+		}
+	})
+}

--- a/internal/vector/vectortest/compliance_test.go
+++ b/internal/vector/vectortest/compliance_test.go
@@ -1,0 +1,26 @@
+package vectortest
+
+import (
+	"testing"
+
+	"github.com/shaktimanai/shaktiman/internal/types"
+	"github.com/shaktimanai/shaktiman/internal/vector"
+)
+
+func TestBruteForceCompliance(t *testing.T) {
+	RunVectorStoreTests(t, func(t *testing.T, dims int) types.VectorStore {
+		t.Helper()
+		return vector.NewBruteForceStore(dims)
+	})
+}
+
+func TestHNSWCompliance(t *testing.T) {
+	RunVectorStoreTests(t, func(t *testing.T, dims int) types.VectorStore {
+		t.Helper()
+		vs, err := vector.NewHNSWStore(vector.HNSWStoreInput{Dim: dims})
+		if err != nil {
+			t.Fatalf("NewHNSWStore: %v", err)
+		}
+		return vs
+	})
+}

--- a/internal/vector/vectortest/suite.go
+++ b/internal/vector/vectortest/suite.go
@@ -1,0 +1,234 @@
+// Package vectortest provides compliance test suites for VectorStore
+// implementations. Any backend (BruteForce, HNSW, Qdrant, pgvector)
+// must pass these tests to be considered a valid implementation.
+package vectortest
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/shaktimanai/shaktiman/internal/types"
+)
+
+// VectorStoreFactory creates a fresh VectorStore for each test.
+// Dims specifies the vector dimensionality to use.
+type VectorStoreFactory func(t *testing.T, dims int) types.VectorStore
+
+// RunVectorStoreTests runs the full compliance suite against a VectorStore.
+func RunVectorStoreTests(t *testing.T, factory VectorStoreFactory) {
+	const dims = 4
+
+	t.Run("Upsert_And_Count", func(t *testing.T) {
+		vs := factory(t, dims)
+		defer vs.Close()
+		ctx := context.Background()
+
+		if err := vs.Upsert(ctx, 1, []float32{0.1, 0.2, 0.3, 0.4}); err != nil {
+			t.Fatalf("Upsert: %v", err)
+		}
+		count, err := vs.Count(ctx)
+		if err != nil {
+			t.Fatalf("Count: %v", err)
+		}
+		if count != 1 {
+			t.Errorf("Count = %d, want 1", count)
+		}
+	})
+
+	t.Run("Upsert_Overwrites", func(t *testing.T) {
+		vs := factory(t, dims)
+		defer vs.Close()
+		ctx := context.Background()
+
+		vs.Upsert(ctx, 1, []float32{0.1, 0.2, 0.3, 0.4})
+		vs.Upsert(ctx, 1, []float32{0.5, 0.6, 0.7, 0.8})
+
+		count, _ := vs.Count(ctx)
+		if count != 1 {
+			t.Errorf("Count after overwrite = %d, want 1", count)
+		}
+	})
+
+	t.Run("UpsertBatch", func(t *testing.T) {
+		vs := factory(t, dims)
+		defer vs.Close()
+		ctx := context.Background()
+
+		err := vs.UpsertBatch(ctx,
+			[]int64{1, 2, 3},
+			[][]float32{
+				{0.1, 0.2, 0.3, 0.4},
+				{0.5, 0.6, 0.7, 0.8},
+				{0.9, 0.8, 0.7, 0.6},
+			})
+		if err != nil {
+			t.Fatalf("UpsertBatch: %v", err)
+		}
+		count, _ := vs.Count(ctx)
+		if count != 3 {
+			t.Errorf("Count = %d, want 3", count)
+		}
+	})
+
+	t.Run("Has", func(t *testing.T) {
+		vs := factory(t, dims)
+		defer vs.Close()
+		ctx := context.Background()
+
+		vs.Upsert(ctx, 42, []float32{0.1, 0.2, 0.3, 0.4})
+
+		has, err := vs.Has(ctx, 42)
+		if err != nil {
+			t.Fatalf("Has(42): %v", err)
+		}
+		if !has {
+			t.Error("expected Has(42) = true")
+		}
+
+		has, _ = vs.Has(ctx, 999)
+		if has {
+			t.Error("expected Has(999) = false")
+		}
+	})
+
+	t.Run("Delete", func(t *testing.T) {
+		vs := factory(t, dims)
+		defer vs.Close()
+		ctx := context.Background()
+
+		vs.Upsert(ctx, 1, []float32{0.1, 0.2, 0.3, 0.4})
+		vs.Upsert(ctx, 2, []float32{0.5, 0.6, 0.7, 0.8})
+
+		if err := vs.Delete(ctx, []int64{1}); err != nil {
+			t.Fatalf("Delete: %v", err)
+		}
+
+		has, _ := vs.Has(ctx, 1)
+		if has {
+			t.Error("expected Has(1) = false after delete")
+		}
+		has, _ = vs.Has(ctx, 2)
+		if !has {
+			t.Error("expected Has(2) = true (not deleted)")
+		}
+	})
+
+	t.Run("Delete_Idempotent", func(t *testing.T) {
+		vs := factory(t, dims)
+		defer vs.Close()
+		ctx := context.Background()
+
+		// Deleting nonexistent IDs should not error
+		if err := vs.Delete(ctx, []int64{999}); err != nil {
+			t.Fatalf("Delete nonexistent: %v", err)
+		}
+	})
+
+	t.Run("Search_CosineSimilarity", func(t *testing.T) {
+		vs := factory(t, dims)
+		defer vs.Close()
+		ctx := context.Background()
+
+		// Insert vectors with known similarity to query
+		vs.Upsert(ctx, 1, []float32{1, 0, 0, 0})    // identical to query
+		vs.Upsert(ctx, 2, []float32{0, 1, 0, 0})    // orthogonal
+		vs.Upsert(ctx, 3, []float32{0.9, 0.1, 0, 0}) // similar to query
+
+		results, err := vs.Search(ctx, []float32{1, 0, 0, 0}, 3)
+		if err != nil {
+			t.Fatalf("Search: %v", err)
+		}
+		if len(results) == 0 {
+			t.Fatal("expected at least 1 result")
+		}
+
+		// First result should be the most similar (chunk 1 or 3)
+		topID := results[0].ChunkID
+		if topID != 1 && topID != 3 {
+			t.Errorf("top result ChunkID = %d, expected 1 or 3", topID)
+		}
+
+		// Scores should be in descending order
+		for i := 1; i < len(results); i++ {
+			if results[i].Score > results[i-1].Score+1e-6 {
+				t.Errorf("results not sorted by score: [%d].Score=%f > [%d].Score=%f",
+					i, results[i].Score, i-1, results[i-1].Score)
+			}
+		}
+	})
+
+	t.Run("Search_TopK", func(t *testing.T) {
+		vs := factory(t, dims)
+		defer vs.Close()
+		ctx := context.Background()
+
+		for i := int64(1); i <= 10; i++ {
+			v := make([]float32, dims)
+			v[0] = float32(i) / 10.0
+			vs.Upsert(ctx, i, v)
+		}
+
+		results, err := vs.Search(ctx, []float32{1, 0, 0, 0}, 3)
+		if err != nil {
+			t.Fatalf("Search: %v", err)
+		}
+		if len(results) > 3 {
+			t.Errorf("Search returned %d results, want <= 3", len(results))
+		}
+	})
+
+	t.Run("Search_EmptyStore", func(t *testing.T) {
+		vs := factory(t, dims)
+		defer vs.Close()
+
+		results, err := vs.Search(context.Background(), []float32{1, 0, 0, 0}, 5)
+		if err != nil {
+			t.Fatalf("Search empty: %v", err)
+		}
+		if len(results) != 0 {
+			t.Errorf("expected 0 results from empty store, got %d", len(results))
+		}
+	})
+
+	t.Run("Search_ScoresNotNaN", func(t *testing.T) {
+		vs := factory(t, dims)
+		defer vs.Close()
+		ctx := context.Background()
+
+		vs.Upsert(ctx, 1, []float32{1, 0, 0, 0})
+		vs.Upsert(ctx, 2, []float32{0, 1, 0, 0})
+
+		results, err := vs.Search(ctx, []float32{1, 0, 0, 0}, 2)
+		if err != nil {
+			t.Fatalf("Search: %v", err)
+		}
+		for _, r := range results {
+			if math.IsNaN(r.Score) {
+				t.Errorf("score is NaN for chunk %d", r.ChunkID)
+			}
+		}
+		// Identical vector should have highest score
+		if len(results) > 0 && results[0].ChunkID != 1 {
+			t.Errorf("expected chunk 1 (identical) as top result, got %d", results[0].ChunkID)
+		}
+	})
+
+	t.Run("Healthy", func(t *testing.T) {
+		vs := factory(t, dims)
+		defer vs.Close()
+
+		if !vs.Healthy(context.Background()) {
+			t.Error("expected Healthy = true")
+		}
+	})
+
+	t.Run("Close_Idempotent", func(t *testing.T) {
+		vs := factory(t, dims)
+		if err := vs.Close(); err != nil {
+			t.Fatalf("first Close: %v", err)
+		}
+		// Second close should not panic (may or may not error)
+		vs.Close()
+	})
+}


### PR DESCRIPTION
Creates reusable test suites that any storage/vector backend must pass (ADR-003 Phase 2d):

MetadataStore suite (internal/storage/storetest/suite.go):
- 17 subtests covering all MetadataStore interface methods
- UpsertFile (insert + update), GetFileByPath, ListFiles, DeleteFile cascade
- InsertChunks + GetByFile + GetByID, DeleteChunksByFile
- InsertSymbols + GetByName + GetByID, DeleteSymbolsByFile
- GetFilePathByID, GetFileIsTestByID, GetIndexStats
- KeywordSearch + empty query

VectorStore suite (internal/vector/vectortest/suite.go):
- 12 subtests covering all VectorStore interface methods
- Upsert + Count, Upsert overwrites, UpsertBatch
- Has (found + not found), Delete + idempotent delete
- Search cosine similarity ordering, TopK limit, empty store
- Score validity (not NaN), Healthy, Close idempotent

Compliance wiring:
- SQLite passes MetadataStore suite (storetest/sqlite_compliance_test.go)
- BruteForce passes VectorStore suite (vectortest/compliance_test.go)
- HNSW passes VectorStore suite (vectortest/compliance_test.go)

Future backends (Postgres, Qdrant, pgvector) will add their own compliance_test.go files that call these same suites.