### PR TITLE
chore: enforce 50% codecov floor

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 50%
+        threshold: 0%
+    patch:
+      default:
+        target: 50%
+        threshold: 0%


### PR DESCRIPTION
Adds a `.codecov.yml` configuration to enforce a minimum coverage floor of 50%. This prevents regressions in test quality as the codebase grows.

Fixes #35