### PR TITLE
ci: add golangci-lint and enforce in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,18 @@ on:
     branches: [master]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,16 @@
+linters:
+  enable:
+    - govet
+    - errcheck
+    - staticcheck
+    - gosec
+    - revive
+    - gosimple
+    - ineffassign
+    - typecheck
+    - unused
+
+run:
+  timeout: 5m
+  build-tags:
+    - sqlite_fts5


### PR DESCRIPTION
Adds `golangci-lint` to the CI workflow with a curated set of linters (govet, errcheck, staticcheck, gosec, revive). This ensures code quality and catches common bugs, especially in CGo and concurrent SQLite access paths.

Fixes #38