### PR TITLE
Feat/better search results with single word queries

### DIFF
--- a/cmd/shaktiman/main.go
+++ b/cmd/shaktiman/main.go
@@ -49,6 +49,7 @@ func main() {
 	rootCmd.AddCommand(diffCmd())
 	rootCmd.AddCommand(enrichmentStatusCmd())
 	rootCmd.AddCommand(summaryCmd())
+	rootCmd.AddCommand(reEmbedCmd())
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
@@ -234,6 +235,46 @@ func isTTY() bool {
 		return false
 	}
 	return fi.Mode()&os.ModeCharDevice != 0
+}
+
+func reEmbedCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "re-embed <project-root>",
+		Short: "Discard existing embeddings and regenerate with current config",
+		Long: `Deletes embeddings.bin and resets all embedded flags in the database.
+After running this, execute 'shaktiman index --embed <project-root>' to regenerate
+all embeddings using the prefixes configured in shaktiman.toml.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			projectRoot := args[0]
+			cfg := types.DefaultConfig(projectRoot)
+			cfg, err := types.LoadConfigFromFile(cfg)
+			if err != nil {
+				return fmt.Errorf("load config: %w", err)
+			}
+			ctx := context.Background()
+
+			store, closer, err := openStore(cfg)
+			if err != nil {
+				return fmt.Errorf("open store: %w", err)
+			}
+			defer closer()
+
+			// Delete embeddings.bin
+			if err := os.Remove(cfg.EmbeddingsPath); err != nil && !os.IsNotExist(err) {
+				return fmt.Errorf("delete embeddings: %w", err)
+			}
+			fmt.Printf("Deleted: %s\n", cfg.EmbeddingsPath)
+
+			// Reset all embedded flags so index --embed regenerates everything
+			if err := store.ResetAllEmbeddedFlags(ctx); err != nil {
+				return fmt.Errorf("reset embedded flags: %w", err)
+			}
+			fmt.Println("Reset embedded flags.")
+			fmt.Printf("Run: shaktiman index --embed %s\n", projectRoot)
+			return nil
+		},
+	}
 }
 
 func statusCmd() *cobra.Command {

--- a/docs/planning/10-fix-semantic-search-identifier-lookup.md
+++ b/docs/planning/10-fix-semantic-search-identifier-lookup.md
@@ -1,0 +1,717 @@
+# 001 — Fix Semantic Search Identifier Lookup
+
+## Problem
+
+Searching for an exact function name like `buildBuyerOptions` via `shaktiman search` returns
+completely unrelated chunks (e.g. `require 'MailchimpTransactional'` from `mandrill_mailer.rb`)
+with near-perfect scores (~0.608), while the correct chunks score too low to appear in the top 10.
+
+## Root Cause
+
+Two compounding causes were confirmed by direct database analysis and score simulation.
+
+### Cause 1: Missing `nomic-embed-text` task prefixes
+
+`nomic-embed-text` was trained with contrastive learning using task-specific prefixes:
+
+- `search_document:` — for documents at index time
+- `search_query:` — for queries at search time
+
+These prefixes are not optional. They are how the model knows whether input is a query seeking
+a match or a document being indexed. Without them, both are embedded in the same generic
+subspace where the geometric relationship between query and document vectors breaks down.
+
+**Confirmed missing** in two places:
+
+```go
+// embed_worker.go:336 — document indexing
+texts[j] = job.Content   // ← raw source code, no prefix
+
+// engine.go:embedQuery — query at search time
+vec, err := e.embedder.Embed(ctx, input.Query)  // ← raw identifier, no prefix
+```
+
+### Cause 2: Short-string hubness in high-dimensional space
+
+`chunk 3095` (`require 'MailchimpTransactional'`) has only **6 tokens**. The query
+`"buildBuyerOptions"` tokenizes to ~3 wordpiece tokens. In a 768-dimension embedding space,
+very short inputs produce vectors dominated by the model's default state rather than content.
+All short, low-entropy strings cluster into the same narrow region — any two short strings
+have artificially high cosine similarity regardless of meaning.
+
+### Proof (from database)
+
+FTS5 correctly finds `buildBuyerOptions` chunks:
+
+```
+chunk 8987:  BM25=-12.65 → normalized keyword score = 0.253
+chunk 9241:  BM25=-11.25 → normalized keyword score = 0.225
+chunk 10449: BM25=-12.05 → normalized keyword score = 0.241
+```
+
+Hybrid ranking weights (after session weight redistribution):
+
+```
+Semantic:   0.4706
+Structural: 0.2353
+Change:     0.1765
+Session:    0.0000  (no access_log entries)
+Keyword:    0.1176
+```
+
+Score simulation for chunk 8987 (no semantic signal):
+
+```
+0.1176 × 0.253  +  0.1765 × 0.7225  =  0.157
+```
+
+Score reconstruction for chunk 3095 (the wrong #1 result, score=0.608):
+
+```
+0.4706 × 1.0  +  0.2353 × 0.04  +  0.1765 × 0.7225  ≈  0.608
+```
+
+`chunk 3095` has semantic ≈ 1.0 for the query `"buildBuyerOptions"` — a near-perfect cosine
+match between `"require 'MailchimpTransactional'"` and the identifier. This is the broken
+embedding signal.
+
+**Maximum possible score for chunk 8987 without semantic (perfect struct+change):**
+
+```
+0.1176×0.253 + 0.1765×0.7225 + 0.2353×1.0 = 0.393
+```
+
+`0.393 < 0.608` — the correct chunk **cannot beat the wrong chunk** under current conditions,
+regardless of structural or change signals. Weight tuning alone does not fix this.
+
+Adversarial simulation of Option A (Keyword=0.50):
+
+```
+chunk 8987 score = 0.209   chunk 3095 score = 0.294   → still loses
+```
+
+Keyword weight must reach ≥ 0.70 before chunk 8987 wins — an extreme and fragile threshold.
+
+---
+
+## Solution
+
+Two independent fixes. Fix 1 corrects the data. Fix 2 is a reliable bypass that works
+regardless of embedding quality.
+
+---
+
+## Fix 1: `nomic-embed-text` Task Prefixes
+
+### 1.1 — Add prefix fields to `Config`
+
+**File:** `internal/types/config.go`
+
+Add to `Config` struct (after `EmbedTimeout`):
+
+```go
+// EmbedQueryPrefix is prepended to query text before embedding.
+// For nomic-embed-text, use "search_query: ".
+EmbedQueryPrefix string
+
+// EmbedDocumentPrefix is prepended to chunk content before embedding.
+// For nomic-embed-text, use "search_document: ".
+EmbedDocumentPrefix string
+```
+
+Add to `DefaultConfig`:
+
+```go
+EmbedQueryPrefix:    "search_query: ",
+EmbedDocumentPrefix: "search_document: ",
+```
+
+Add to `tomlEmbedding` struct:
+
+```go
+type tomlEmbedding struct {
+    OllamaURL      *string `toml:"ollama_url"`
+    Model          *string `toml:"model"`
+    Dims           *int    `toml:"dims"`
+    BatchSize      *int    `toml:"batch_size"`
+    Timeout        *string `toml:"timeout"`
+    QueryPrefix    *string `toml:"query_prefix"`     // new
+    DocumentPrefix *string `toml:"document_prefix"`  // new
+}
+```
+
+Add to `LoadConfigFromFile` below the existing `[embedding]` parsing block:
+
+```go
+if v := tc.Embedding.QueryPrefix; v != nil {
+    cfg.EmbedQueryPrefix = *v
+}
+if v := tc.Embedding.DocumentPrefix; v != nil {
+    cfg.EmbedDocumentPrefix = *v
+}
+```
+
+Update `sampleConfig` const:
+
+```toml
+[embedding]
+# ollama_url = "http://localhost:11434"
+# model = "nomic-embed-text"
+# dims = 768
+# batch_size = 128
+# timeout = "120s"
+# query_prefix = "search_query: "       # Task prefix for query embedding (nomic-embed-text)
+# document_prefix = "search_document: " # Task prefix for document embedding (nomic-embed-text)
+```
+
+---
+
+### 1.2 — Apply document prefix at index time
+
+**File:** `internal/vector/embed_worker.go`
+
+Add `documentPrefix` field and input:
+
+```go
+type EmbedWorkerInput struct {
+    Store          types.VectorStore
+    Embedder       *OllamaClient
+    BatchSize      int
+    OnBatchDone    func(chunkIDs []int64)
+    DocumentPrefix string  // new
+}
+
+type EmbedWorker struct {
+    // ... existing fields ...
+    documentPrefix string  // new
+}
+```
+
+In `NewEmbedWorker`, assign: `documentPrefix: input.DocumentPrefix`
+
+In `processBatch` (line ~160):
+
+```go
+texts := make([]string, len(batch))
+for i, j := range batch {
+    texts[i] = w.documentPrefix + j.Content  // was: j.Content
+}
+```
+
+In `reconcileAndEmbed` (line ~332):
+
+```go
+for j, job := range needEmbed {
+    texts[j] = w.documentPrefix + job.Content  // was: job.Content
+    needIDs[j] = job.ChunkID
+}
+```
+
+In `retryDeferred` (line ~476):
+
+```go
+vecs, err := w.embedder.EmbedBatch(ctx, []string{w.documentPrefix + dc.job.Content})
+// was: []string{dc.job.Content}
+```
+
+---
+
+### 1.3 — Apply query prefix at search time
+
+**File:** `internal/core/engine.go`
+
+Add `queryPrefix` field to `QueryEngine`:
+
+```go
+type QueryEngine struct {
+    // ... existing fields ...
+    queryPrefix string  // new
+}
+```
+
+Add setter (consistent with `SetVectorStore`/`SetSessionStore` pattern):
+
+```go
+func (e *QueryEngine) SetQueryPrefix(prefix string) {
+    e.queryPrefix = prefix
+}
+```
+
+Update `embedQuery` to use prefixed string as both the input and cache key:
+
+```go
+func (e *QueryEngine) embedQuery(ctx context.Context, query string) ([]float32, error) {
+    prefixed := e.queryPrefix + query
+    if vec, ok := e.embedCache.Get(prefixed); ok {
+        return vec, nil
+    }
+    vec, err := e.embedder.Embed(ctx, prefixed)
+    if err != nil {
+        return nil, err
+    }
+    e.embedCache.Put(prefixed, vec)
+    return vec, nil
+}
+```
+
+The cache key uses the prefixed string so a prefix change (e.g. switching models) does not
+serve stale cached vectors.
+
+---
+
+### 1.4 — Wire prefix config into daemon
+
+**File:** `internal/daemon/daemon.go`
+
+Where `EmbedWorker` is constructed, pass the document prefix:
+
+```go
+embedWorker := vector.NewEmbedWorker(vector.EmbedWorkerInput{
+    Store:          vectorStore,
+    Embedder:       ollamaClient,
+    BatchSize:      cfg.EmbedBatchSize,
+    OnBatchDone:    ...,
+    DocumentPrefix: cfg.EmbedDocumentPrefix,  // new
+})
+```
+
+Where `QueryEngine` is constructed, set the query prefix:
+
+```go
+engine.SetQueryPrefix(cfg.EmbedQueryPrefix)
+```
+
+---
+
+### 1.5 — Add `re-embed` CLI command
+
+**File:** `cmd/shaktiman/main.go`
+
+All existing embeddings in `embeddings.bin` were generated without prefixes and must be
+discarded. Add a `re-embed` subcommand that deletes `embeddings.bin` and resets all
+`embedded = 0` flags in the database so `shaktiman index --embed` regenerates everything.
+
+```go
+func reEmbedCmd() *cobra.Command {
+    return &cobra.Command{
+        Use:   "re-embed <project-root>",
+        Short: "Discard existing embeddings and regenerate with current config",
+        Long: `Deletes embeddings.bin and resets all embedded flags in the database.
+After running this, execute 'shaktiman index --embed <project-root>' to regenerate
+all embeddings using the prefixes configured in shaktiman.toml.`,
+        Args:  cobra.ExactArgs(1),
+        RunE: func(cmd *cobra.Command, args []string) error {
+            projectRoot := args[0]
+            cfg := types.DefaultConfig(projectRoot)
+            cfg, err := types.LoadConfigFromFile(cfg)
+            if err != nil {
+                return fmt.Errorf("load config: %w", err)
+            }
+            ctx := context.Background()
+
+            store, closer, err := openStore(cfg)
+            if err != nil {
+                return fmt.Errorf("open store: %w", err)
+            }
+            defer closer()
+
+            // Delete embeddings.bin
+            if err := os.Remove(cfg.EmbeddingsPath); err != nil && !os.IsNotExist(err) {
+                return fmt.Errorf("delete embeddings: %w", err)
+            }
+            fmt.Printf("Deleted: %s\n", cfg.EmbeddingsPath)
+
+            // Reset all embedded flags
+            ws, ok := store.(types.WriterStore)
+            if !ok {
+                return fmt.Errorf("store does not implement WriterStore")
+            }
+            if err := ws.ResetAllEmbeddedFlags(ctx); err != nil {
+                return fmt.Errorf("reset embedded flags: %w", err)
+            }
+            fmt.Println("Reset embedded flags.")
+            fmt.Printf("Run: shaktiman index --embed %s\n", projectRoot)
+            return nil
+        },
+    }
+}
+```
+
+Register: `rootCmd.AddCommand(reEmbedCmd())`
+
+**Migration path for existing deployments:**
+
+```bash
+shaktiman re-embed /path/to/project
+shaktiman index --embed /path/to/project
+```
+
+---
+
+## Fix 2: Symbol-Exact Pre-Search Bypass
+
+Runs before hybrid search for identifier-style queries. Queries the `symbols` table directly
+(which already correctly contains `buildBuyerOptions`). Returns score=1.0 for exact matches,
+prepended before hybrid results. Independent of embedding quality.
+
+### 2.1 — Add `GetSymbolByNameCI` to the store
+
+**File:** `internal/storage/sqlite/metadata.go`
+
+```go
+// GetSymbolByNameCI returns symbols whose name matches case-insensitively.
+func (s *Store) GetSymbolByNameCI(ctx context.Context, name string) ([]types.SymbolRecord, error) {
+    rows, err := s.db.QueryContext(ctx, `
+        SELECT id, chunk_id, file_id, name, qualified_name, kind,
+               line, signature, visibility, is_exported
+        FROM symbols WHERE name = ? COLLATE NOCASE`, name)
+    if err != nil {
+        return nil, fmt.Errorf("get symbols named (ci) %s: %w", name, err)
+    }
+    defer rows.Close()
+    return scanSymbols(rows)
+}
+```
+
+**File:** `internal/types/interfaces.go`
+
+Add to `MetadataStore` interface:
+
+```go
+// GetSymbolByNameCI returns symbols matching the given name case-insensitively.
+GetSymbolByNameCI(ctx context.Context, name string) ([]types.SymbolRecord, error)
+```
+
+---
+
+### 2.2 — Add `lookup.go` to the core package
+
+**File:** `internal/core/lookup.go` (new file)
+
+```go
+package core
+
+import (
+    "context"
+    "strings"
+    "unicode"
+
+    "github.com/shaktimanai/shaktiman/internal/types"
+)
+
+// isIdentifierQuery returns true when query looks like a single code identifier:
+// no whitespace, contains only letters/digits/underscores, has at least one letter.
+// Matches camelCase, PascalCase, snake_case, SCREAMING_SNAKE.
+func isIdentifierQuery(query string) bool {
+    if strings.ContainsAny(query, " \t\n\r") {
+        return false
+    }
+    if len(query) < 2 {
+        return false
+    }
+    hasLetter := false
+    for _, r := range query {
+        if unicode.IsLetter(r) {
+            hasLetter = true
+        } else if !unicode.IsDigit(r) && r != '_' {
+            return false
+        }
+    }
+    return hasLetter
+}
+
+// SymbolExactSearch looks up chunks by exact symbol name.
+// Returns nil (not an error) when no symbols match, so callers fall through gracefully.
+// Tries case-sensitive match first, then case-insensitive fallback.
+// Score is always 1.0 — exact symbol matches are maximum relevance.
+func SymbolExactSearch(ctx context.Context, store types.MetadataStore, query string, filter TestFilter) ([]types.ScoredResult, error) {
+    // Case-sensitive first (cheaper, more precise)
+    syms, err := store.GetSymbolByName(ctx, query)
+    if err != nil {
+        return nil, err
+    }
+    // Case-insensitive fallback
+    if len(syms) == 0 {
+        syms, err = store.GetSymbolByNameCI(ctx, query)
+        if err != nil {
+            return nil, err
+        }
+    }
+    if len(syms) == 0 {
+        return nil, nil
+    }
+
+    // Collect unique chunk IDs respecting test filter
+    type symEntry struct {
+        sym  types.SymbolRecord
+        path string
+    }
+    seen := make(map[int64]bool, len(syms))
+    var entries []symEntry
+
+    for _, sym := range syms {
+        if sym.ChunkID == 0 || seen[sym.ChunkID] {
+            continue
+        }
+        isTest, err := store.GetFileIsTestByID(ctx, sym.FileID)
+        if err != nil {
+            continue
+        }
+        if filter.ExcludeTests && isTest {
+            continue
+        }
+        if filter.TestOnly && !isTest {
+            continue
+        }
+        path, err := store.GetFilePathByID(ctx, sym.FileID)
+        if err != nil {
+            continue
+        }
+        seen[sym.ChunkID] = true
+        entries = append(entries, symEntry{sym: sym, path: path})
+    }
+
+    if len(entries) == 0 {
+        return nil, nil
+    }
+
+    // Batch hydration path (1 query instead of N)
+    chunkIDs := make([]int64, len(entries))
+    for i, e := range entries {
+        chunkIDs[i] = e.sym.ChunkID
+    }
+
+    if bs, ok := store.(types.BatchMetadataStore); ok {
+        hydrated, err := bs.BatchHydrateChunks(ctx, chunkIDs)
+        if err == nil {
+            hydratedMap := make(map[int64]types.HydratedChunk, len(hydrated))
+            for _, h := range hydrated {
+                hydratedMap[h.ChunkID] = h
+            }
+            results := make([]types.ScoredResult, 0, len(entries))
+            for _, e := range entries {
+                h, ok := hydratedMap[e.sym.ChunkID]
+                if !ok {
+                    continue
+                }
+                results = append(results, types.ScoredResult{
+                    ChunkID:    h.ChunkID,
+                    Score:      1.0,
+                    Path:       h.Path,
+                    SymbolName: e.sym.Name,
+                    Kind:       h.Kind,
+                    StartLine:  h.StartLine,
+                    EndLine:    h.EndLine,
+                    Content:    h.Content,
+                    TokenCount: h.TokenCount,
+                })
+            }
+            return results, nil
+        }
+        // fall through to per-item on batch error
+    }
+
+    // Per-item fallback
+    results := make([]types.ScoredResult, 0, len(entries))
+    for _, e := range entries {
+        chunk, err := store.GetChunkByID(ctx, e.sym.ChunkID)
+        if err != nil || chunk == nil {
+            continue
+        }
+        results = append(results, types.ScoredResult{
+            ChunkID:    chunk.ID,
+            Score:      1.0,
+            Path:       e.path,
+            SymbolName: e.sym.Name,
+            Kind:       chunk.Kind,
+            StartLine:  chunk.StartLine,
+            EndLine:    chunk.EndLine,
+            Content:    chunk.Content,
+            TokenCount: chunk.TokenCount,
+        })
+    }
+    return results, nil
+}
+```
+
+---
+
+### 2.3 — Integrate into `searchSemantic`
+
+**File:** `internal/core/engine.go`
+
+In `searchSemantic`, before the keyword search call, add the symbol exact lookup block.
+After `HybridRank`, merge exact matches at the front:
+
+```go
+func (e *QueryEngine) searchSemantic(ctx context.Context, input SearchInput, level FallbackLevel) ([]types.ScoredResult, error) {
+    filter := TestFilter{ExcludeTests: input.ExcludeTests, TestOnly: input.TestOnly}
+
+    // Symbol exact lookup for identifier-style queries.
+    var exactMatches []types.ScoredResult
+    if isIdentifierQuery(input.Query) {
+        var err error
+        exactMatches, err = SymbolExactSearch(ctx, e.store, input.Query, filter)
+        if err != nil {
+            e.logger.Warn("symbol exact search failed, continuing", "err", err)
+        }
+    }
+
+    // ... existing kwResults, queryVec, semResults, mergeResults, HybridRank unchanged ...
+
+    // Prepend exact matches; append hybrid results deduplicating by chunk ID.
+    if len(exactMatches) > 0 {
+        seen := make(map[int64]bool, len(exactMatches))
+        for _, r := range exactMatches {
+            seen[r.ChunkID] = true
+        }
+        for _, r := range ranked {
+            if !seen[r.ChunkID] {
+                exactMatches = append(exactMatches, r)
+            }
+        }
+        ranked = exactMatches
+    }
+
+    if len(ranked) > input.MaxResults {
+        ranked = ranked[:input.MaxResults]
+    }
+    if input.MinScore > 0 {
+        ranked = filterByScore(ranked, input.MinScore)
+    }
+    e.recordSession(ranked)
+    return ranked, nil
+}
+```
+
+---
+
+### 2.4 — Integrate into `searchKeyword`
+
+**File:** `internal/core/engine.go`
+
+Same pattern in `searchKeyword`:
+
+```go
+func (e *QueryEngine) searchKeyword(ctx context.Context, input SearchInput) ([]types.ScoredResult, error) {
+    filter := TestFilter{ExcludeTests: input.ExcludeTests, TestOnly: input.TestOnly}
+
+    var exactMatches []types.ScoredResult
+    if isIdentifierQuery(input.Query) {
+        var err error
+        exactMatches, err = SymbolExactSearch(ctx, e.store, input.Query, filter)
+        if err != nil {
+            e.logger.Warn("symbol exact search failed, continuing", "err", err)
+        }
+    }
+
+    results, err := KeywordSearch(ctx, e.store, input.Query, input.MaxResults, filter)
+    if err != nil {
+        return nil, fmt.Errorf("keyword search: %w", err)
+    }
+
+    if len(results) == 0 && len(exactMatches) == 0 {
+        pkg, err := FilesystemFallback(ctx, e.projectRoot, input.Query, 4096)
+        if err != nil {
+            return nil, fmt.Errorf("filesystem fallback: %w", err)
+        }
+        return pkg.Chunks, nil
+    }
+
+    results = HybridRank(ctx, HybridRankInput{
+        Candidates:    results,
+        Store:         e.store,
+        Weights:       DefaultRankWeights(),
+        SemanticReady: false,
+        SessionScorer: e.sessionScorer(),
+    })
+
+    // Prepend exact matches
+    if len(exactMatches) > 0 {
+        seen := make(map[int64]bool, len(exactMatches))
+        for _, r := range exactMatches {
+            seen[r.ChunkID] = true
+        }
+        for _, r := range results {
+            if !seen[r.ChunkID] {
+                exactMatches = append(exactMatches, r)
+            }
+        }
+        results = exactMatches
+    }
+
+    if input.MinScore > 0 {
+        results = filterByScore(results, input.MinScore)
+    }
+    e.recordSession(results)
+    return results, nil
+}
+```
+
+---
+
+## Fix 3: FTS5 Prefix Search Support (optional, minor)
+
+**File:** `internal/storage/sqlite/fts.go`
+
+In `sanitizeFTSQuery`, allow trailing `*` to enable FTS5 prefix search so partial identifier
+searches like `"buildBuyer*"` find `buildBuyerOptions`:
+
+```go
+// Current: terms = append(terms, `"`+clean+`"`)
+// Replace with:
+if strings.HasSuffix(clean, "*") {
+    base := strings.TrimRight(clean, "*")
+    if base != "" {
+        terms = append(terms, `"`+base+`"*`)
+    }
+} else {
+    terms = append(terms, `"`+clean+`"`)
+}
+```
+
+---
+
+## Execution Order
+
+| Step | File(s) | Depends on |
+|------|---------|------------|
+| 1. Config prefix fields | `internal/types/config.go` | — |
+| 2. Document prefix in EmbedWorker | `internal/vector/embed_worker.go` | Step 1 |
+| 3. Query prefix in QueryEngine | `internal/core/engine.go` | Step 1 |
+| 4. Wire config in daemon | `internal/daemon/daemon.go` | Steps 1–3 |
+| 5. `re-embed` CLI command | `cmd/shaktiman/main.go` | Step 1 |
+| 6. Run `re-embed` + `index --embed` | CLI | Steps 1–5 |
+| 7. `GetSymbolByNameCI` on store | `internal/storage/sqlite/metadata.go`, `internal/types/interfaces.go` | — |
+| 8. `lookup.go` — `isIdentifierQuery` + `SymbolExactSearch` | `internal/core/lookup.go` | Step 7 |
+| 9. Integrate into `searchSemantic` + `searchKeyword` | `internal/core/engine.go` | Step 8 |
+| 10. FTS prefix search (optional) | `internal/storage/sqlite/fts.go` | — |
+
+Steps 7–9 are independent of steps 1–6 and can be implemented and verified before re-embedding.
+
+---
+
+## Verification
+
+Fix 2 (symbol lookup) can be verified immediately without re-embedding:
+
+```bash
+cd /Users/bigbinary/BB/agentinbox
+shaktiman search "buildBuyerOptions" --format json | jq '.[0:3] | .[].symbol_name'
+# Expected: "buildBuyerOptions", "buildBuyerOptions", "buildBuyerOptions"
+```
+
+Fix 1 requires re-embedding first, then:
+
+```bash
+shaktiman search "buildBuyerOptions" --format json | jq '.[0:3] | .[] | {score, symbol_name, path}'
+# Expected: score ≥ 0.85, symbol_name = "buildBuyerOptions" for top 3 results
+```
+
+Regression check — natural language queries should still work:
+
+```bash
+shaktiman search "how does routing work"
+shaktiman search "authentication flow"
+# Expected: semantically relevant results, not just symbol-name matches
+```

--- a/internal/core/engine.go
+++ b/internal/core/engine.go
@@ -18,8 +18,9 @@ type QueryEngine struct {
 	vectorStore  types.VectorStore // nil if embeddings disabled
 	embedder     types.Embedder    // nil if embeddings disabled
 	embedCache   *vector.EmbedCache
-	embedReady   func() bool       // checks if embedding service is available
-	sessionStore *SessionStore     // nil if session scoring disabled
+	embedReady   func() bool   // checks if embedding service is available
+	sessionStore *SessionStore // nil if session scoring disabled
+	queryPrefix  string        // prepended to query text before embedding (e.g. "search_query: ")
 }
 
 // NewQueryEngine creates an engine backed by the given store.
@@ -43,6 +44,12 @@ func (e *QueryEngine) SetVectorStore(vs types.VectorStore, embedder types.Embedd
 // SetSessionStore attaches a session store for session-aware ranking.
 func (e *QueryEngine) SetSessionStore(ss *SessionStore) {
 	e.sessionStore = ss
+}
+
+// SetQueryPrefix configures the prefix prepended to query text before embedding.
+// For nomic-embed-text, use "search_query: ".
+func (e *QueryEngine) SetQueryPrefix(prefix string) {
+	e.queryPrefix = prefix
 }
 
 // SearchInput configures a search operation.
@@ -143,6 +150,17 @@ func (e *QueryEngine) determineLevel(ctx context.Context) FallbackLevel {
 func (e *QueryEngine) searchSemantic(ctx context.Context, input SearchInput, level FallbackLevel) ([]types.ScoredResult, error) {
 	filter := TestFilter{ExcludeTests: input.ExcludeTests, TestOnly: input.TestOnly}
 
+	// Symbol exact lookup for identifier-style queries (camelCase, snake_case, etc.).
+	// Returns score=1.0 matches that are prepended before hybrid results.
+	var exactMatches []types.ScoredResult
+	if isIdentifierQuery(input.Query) {
+		var symErr error
+		exactMatches, symErr = SymbolExactSearch(ctx, e.store, input.Query, filter)
+		if symErr != nil {
+			e.logger.Warn("symbol exact search failed, continuing", "err", symErr)
+		}
+	}
+
 	// Get keyword candidates
 	kwResults, err := KeywordSearch(ctx, e.store, input.Query, input.MaxResults*2, filter)
 	if err != nil {
@@ -182,6 +200,20 @@ func (e *QueryEngine) searchSemantic(ctx context.Context, input SearchInput, lev
 		SessionScorer:  e.sessionScorer(),
 	})
 
+	// Prepend exact symbol matches at the front; append hybrid results deduplicating by chunk ID.
+	if len(exactMatches) > 0 {
+		seen := make(map[int64]bool, len(exactMatches))
+		for _, r := range exactMatches {
+			seen[r.ChunkID] = true
+		}
+		for _, r := range ranked {
+			if !seen[r.ChunkID] {
+				exactMatches = append(exactMatches, r)
+			}
+		}
+		ranked = exactMatches
+	}
+
 	if len(ranked) > input.MaxResults {
 		ranked = ranked[:input.MaxResults]
 	}
@@ -195,12 +227,23 @@ func (e *QueryEngine) searchSemantic(ctx context.Context, input SearchInput, lev
 // searchKeyword runs keyword-only search with structural + change signals.
 func (e *QueryEngine) searchKeyword(ctx context.Context, input SearchInput) ([]types.ScoredResult, error) {
 	filter := TestFilter{ExcludeTests: input.ExcludeTests, TestOnly: input.TestOnly}
+
+	// Symbol exact lookup for identifier-style queries.
+	var exactMatches []types.ScoredResult
+	if isIdentifierQuery(input.Query) {
+		var symErr error
+		exactMatches, symErr = SymbolExactSearch(ctx, e.store, input.Query, filter)
+		if symErr != nil {
+			e.logger.Warn("symbol exact search failed, continuing", "err", symErr)
+		}
+	}
+
 	results, err := KeywordSearch(ctx, e.store, input.Query, input.MaxResults, filter)
 	if err != nil {
 		return nil, fmt.Errorf("keyword search: %w", err)
 	}
 
-	if len(results) == 0 {
+	if len(results) == 0 && len(exactMatches) == 0 {
 		pkg, err := FilesystemFallback(ctx, e.projectRoot, input.Query, 4096)
 		if err != nil {
 			return nil, fmt.Errorf("filesystem fallback: %w", err)
@@ -215,6 +258,21 @@ func (e *QueryEngine) searchKeyword(ctx context.Context, input SearchInput) ([]t
 		SemanticReady: false,
 		SessionScorer: e.sessionScorer(),
 	})
+
+	// Prepend exact symbol matches at the front; append keyword results deduplicating by chunk ID.
+	if len(exactMatches) > 0 {
+		seen := make(map[int64]bool, len(exactMatches))
+		for _, r := range exactMatches {
+			seen[r.ChunkID] = true
+		}
+		for _, r := range results {
+			if !seen[r.ChunkID] {
+				exactMatches = append(exactMatches, r)
+			}
+		}
+		results = exactMatches
+	}
+
 	if input.MinScore > 0 {
 		results = filterByScore(results, input.MinScore)
 	}
@@ -275,15 +333,18 @@ func (e *QueryEngine) contextKeyword(ctx context.Context, input ContextInput) (*
 }
 
 // embedQuery produces or retrieves a cached embedding for the query text.
+// The queryPrefix is prepended before embedding and used as the cache key,
+// so a prefix change (e.g. switching models) does not return stale cached vectors.
 func (e *QueryEngine) embedQuery(ctx context.Context, query string) ([]float32, error) {
-	if vec, ok := e.embedCache.Get(query); ok {
+	prefixed := e.queryPrefix + query
+	if vec, ok := e.embedCache.Get(prefixed); ok {
 		return vec, nil
 	}
-	vec, err := e.embedder.Embed(ctx, query)
+	vec, err := e.embedder.Embed(ctx, prefixed)
 	if err != nil {
 		return nil, err
 	}
-	e.embedCache.Put(query, vec)
+	e.embedCache.Put(prefixed, vec)
 	return vec, nil
 }
 

--- a/internal/core/lookup.go
+++ b/internal/core/lookup.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"time"
+	"unicode"
 
 	"github.com/shaktimanai/shaktiman/internal/format"
 	"github.com/shaktimanai/shaktiman/internal/types"
@@ -252,6 +253,137 @@ type EnrichmentStatusInput struct {
 	VectorStore types.VectorStore // nil ok
 	PendingFn   func() int       // nil → 0
 	CircuitFn   func() string    // nil → "n/a"
+}
+
+// isIdentifierQuery returns true when query looks like a single code identifier:
+// no whitespace, contains only letters/digits/underscores, has at least one letter.
+// Matches camelCase, PascalCase, snake_case, SCREAMING_SNAKE_CASE.
+func isIdentifierQuery(query string) bool {
+	if len(query) < 2 {
+		return false
+	}
+	hasLetter := false
+	for _, r := range query {
+		if unicode.IsLetter(r) {
+			hasLetter = true
+		} else if !unicode.IsDigit(r) && r != '_' {
+			return false
+		}
+	}
+	return hasLetter
+}
+
+// SymbolExactSearch looks up chunks by exact symbol name.
+// Returns nil (not an error) when no symbols match, so callers fall through gracefully.
+// Tries case-sensitive match first, then case-insensitive fallback.
+// Score is always 1.0 — exact symbol matches are maximum relevance.
+func SymbolExactSearch(ctx context.Context, store types.MetadataStore, query string, filter TestFilter) ([]types.ScoredResult, error) {
+	// Case-sensitive first (cheaper, more precise)
+	syms, err := store.GetSymbolByName(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	// Case-insensitive fallback
+	if len(syms) == 0 {
+		syms, err = store.GetSymbolByNameCI(ctx, query)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if len(syms) == 0 {
+		return nil, nil
+	}
+
+	// Collect unique chunk IDs respecting test filter
+	type symEntry struct {
+		sym  types.SymbolRecord
+		path string
+	}
+	seen := make(map[int64]bool, len(syms))
+	var entries []symEntry
+
+	for _, sym := range syms {
+		if sym.ChunkID == 0 || seen[sym.ChunkID] {
+			continue
+		}
+		isTest, err := store.GetFileIsTestByID(ctx, sym.FileID)
+		if err != nil {
+			continue
+		}
+		if filter.ExcludeTests && isTest {
+			continue
+		}
+		if filter.TestOnly && !isTest {
+			continue
+		}
+		path, err := store.GetFilePathByID(ctx, sym.FileID)
+		if err != nil {
+			continue
+		}
+		seen[sym.ChunkID] = true
+		entries = append(entries, symEntry{sym: sym, path: path})
+	}
+
+	if len(entries) == 0 {
+		return nil, nil
+	}
+
+	// Batch hydration path (1 query instead of N)
+	chunkIDs := make([]int64, len(entries))
+	for i, e := range entries {
+		chunkIDs[i] = e.sym.ChunkID
+	}
+
+	if bs, ok := store.(types.BatchMetadataStore); ok {
+		hydrated, err := bs.BatchHydrateChunks(ctx, chunkIDs)
+		if err == nil {
+			hydratedMap := make(map[int64]types.HydratedChunk, len(hydrated))
+			for _, h := range hydrated {
+				hydratedMap[h.ChunkID] = h
+			}
+			results := make([]types.ScoredResult, 0, len(entries))
+			for _, e := range entries {
+				h, ok := hydratedMap[e.sym.ChunkID]
+				if !ok {
+					continue
+				}
+				results = append(results, types.ScoredResult{
+					ChunkID:    h.ChunkID,
+					Score:      1.0,
+					Path:       h.Path,
+					SymbolName: e.sym.Name,
+					Kind:       h.Kind,
+					StartLine:  h.StartLine,
+					EndLine:    h.EndLine,
+					Content:    h.Content,
+					TokenCount: h.TokenCount,
+				})
+			}
+			return results, nil
+		}
+		// fall through to per-item on batch error
+	}
+
+	// Per-item fallback
+	results := make([]types.ScoredResult, 0, len(entries))
+	for _, e := range entries {
+		chunk, err := store.GetChunkByID(ctx, e.sym.ChunkID)
+		if err != nil || chunk == nil {
+			continue
+		}
+		results = append(results, types.ScoredResult{
+			ChunkID:    chunk.ID,
+			Score:      1.0,
+			Path:       e.path,
+			SymbolName: e.sym.Name,
+			Kind:       chunk.Kind,
+			StartLine:  chunk.StartLine,
+			EndLine:    chunk.EndLine,
+			Content:    chunk.Content,
+			TokenCount: chunk.TokenCount,
+		})
+	}
+	return results, nil
 }
 
 // GetEnrichmentStatus returns enrichment and embedding progress.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -106,9 +106,10 @@ func (d *Daemon) initEmbedding() {
 	})
 
 	worker := vector.NewEmbedWorker(vector.EmbedWorkerInput{
-		Store:     vs,
-		Embedder:  client,
-		BatchSize: d.cfg.EmbedBatchSize,
+		Store:          vs,
+		Embedder:       client,
+		BatchSize:      d.cfg.EmbedBatchSize,
+		DocumentPrefix: d.cfg.EmbedDocumentPrefix,
 		OnBatchDone: func(chunkIDs []int64) {
 			if err := d.store.MarkChunksEmbedded(context.Background(), chunkIDs); err != nil {
 				d.logger.Warn("mark chunks embedded failed", "err", err)
@@ -118,6 +119,7 @@ func (d *Daemon) initEmbedding() {
 
 	d.embedWorker = worker
 	d.engine.SetVectorStore(vs, client, worker.EmbedReady)
+	d.engine.SetQueryPrefix(d.cfg.EmbedQueryPrefix)
 }
 
 // Start starts background services and the MCP server.

--- a/internal/storage/postgres/metadata.go
+++ b/internal/storage/postgres/metadata.go
@@ -269,6 +269,18 @@ func (s *PgStore) GetSymbolByName(ctx context.Context, name string) ([]types.Sym
 	return scanSymbols(rows)
 }
 
+func (s *PgStore) GetSymbolByNameCI(ctx context.Context, name string) ([]types.SymbolRecord, error) {
+	rows, err := s.query(ctx, `
+		SELECT id, chunk_id, file_id, name, qualified_name, kind,
+		       line, signature, visibility, is_exported
+		FROM symbols WHERE name ILIKE $1`, name)
+	if err != nil {
+		return nil, fmt.Errorf("get symbols named (ci) %s: %w", name, err)
+	}
+	defer rows.Close()
+	return scanSymbols(rows)
+}
+
 func (s *PgStore) GetSymbolByID(ctx context.Context, id int64) (*types.SymbolRecord, error) {
 	var sym types.SymbolRecord
 	err := s.queryRow(ctx, `

--- a/internal/storage/sqlite/fts.go
+++ b/internal/storage/sqlite/fts.go
@@ -123,7 +123,15 @@ func sanitizeFTSQuery(query string) string {
 		}, w)
 		clean = strings.TrimSpace(clean)
 		if clean != "" {
-			terms = append(terms, `"`+clean+`"`)
+			// Trailing * enables FTS5 prefix search: "term"* matches "termFoo", "termBar", etc.
+			if strings.HasSuffix(clean, "*") {
+				base := strings.TrimRight(clean, "*")
+				if base != "" {
+					terms = append(terms, `"`+base+`"*`)
+				}
+			} else {
+				terms = append(terms, `"`+clean+`"`)
+			}
 		}
 	}
 	if len(terms) == 0 {

--- a/internal/storage/sqlite/metadata.go
+++ b/internal/storage/sqlite/metadata.go
@@ -334,7 +334,7 @@ func (s *Store) GetSymbolsByFile(ctx context.Context, fileID int64) ([]types.Sym
 	return scanSymbols(rows)
 }
 
-// GetSymbolByName returns symbols matching the given name.
+// GetSymbolByName returns symbols matching the given name (case-sensitive).
 func (s *Store) GetSymbolByName(ctx context.Context, name string) ([]types.SymbolRecord, error) {
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT id, chunk_id, file_id, name, qualified_name, kind,
@@ -342,6 +342,20 @@ func (s *Store) GetSymbolByName(ctx context.Context, name string) ([]types.Symbo
 		FROM symbols WHERE name = ?`, name)
 	if err != nil {
 		return nil, fmt.Errorf("get symbols named %s: %w", name, err)
+	}
+	defer rows.Close()
+	return scanSymbols(rows)
+}
+
+// GetSymbolByNameCI returns symbols matching the given name case-insensitively.
+// Used as a fallback when an exact case-sensitive match yields no results.
+func (s *Store) GetSymbolByNameCI(ctx context.Context, name string) ([]types.SymbolRecord, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, chunk_id, file_id, name, qualified_name, kind,
+		       line, signature, visibility, is_exported
+		FROM symbols WHERE name = ? COLLATE NOCASE`, name)
+	if err != nil {
+		return nil, fmt.Errorf("get symbols named (ci) %s: %w", name, err)
 	}
 	defer rows.Close()
 	return scanSymbols(rows)

--- a/internal/types/config.go
+++ b/internal/types/config.go
@@ -61,6 +61,10 @@ type Config struct {
 	// Embedding timeout
 	EmbedTimeout time.Duration // HTTP timeout per embedding request (default: 120s)
 
+	// Embedding task prefixes (model-specific, e.g. nomic-embed-text)
+	EmbedQueryPrefix    string // prepended to query text before embedding (e.g. "search_query: ")
+	EmbedDocumentPrefix string // prepended to chunk content before embedding (e.g. "search_document: ")
+
 	// Test file detection patterns (glob patterns and directory prefixes)
 	TestPatterns []string // e.g. ["*_test.go", "testdata/", "*.test.ts"]
 }
@@ -100,7 +104,9 @@ func DefaultConfig(projectRoot string) Config {
 
 		QdrantCollection: "shaktiman",
 
-		EmbedTimeout: 120 * time.Second,
+		EmbedTimeout:        120 * time.Second,
+		EmbedQueryPrefix:    "search_query: ",
+		EmbedDocumentPrefix: "search_document: ",
 	}
 }
 
@@ -154,11 +160,13 @@ type tomlQdrant struct {
 }
 
 type tomlEmbedding struct {
-	OllamaURL *string `toml:"ollama_url"`
-	Model     *string `toml:"model"`
-	Dims      *int    `toml:"dims"`
-	BatchSize *int    `toml:"batch_size"`
-	Timeout   *string `toml:"timeout"`
+	OllamaURL      *string `toml:"ollama_url"`
+	Model          *string `toml:"model"`
+	Dims           *int    `toml:"dims"`
+	BatchSize      *int    `toml:"batch_size"`
+	Timeout        *string `toml:"timeout"`
+	QueryPrefix    *string `toml:"query_prefix"`
+	DocumentPrefix *string `toml:"document_prefix"`
 }
 
 // LoadConfigFromFile reads shaktiman.toml and merges values into cfg.
@@ -286,6 +294,12 @@ func LoadConfigFromFile(cfg Config) (Config, error) {
 		}
 		cfg.EmbedTimeout = d
 	}
+	if v := tc.Embedding.QueryPrefix; v != nil {
+		cfg.EmbedQueryPrefix = *v
+	}
+	if v := tc.Embedding.DocumentPrefix; v != nil {
+		cfg.EmbedDocumentPrefix = *v
+	}
 
 	// Environment variable overrides for secrets (highest priority after CLI flags)
 	if v := os.Getenv("SHAKTIMAN_POSTGRES_URL"); v != "" {
@@ -348,6 +362,8 @@ const sampleConfig = `# Shaktiman configuration
 # dims = 768                             # Vector dimensionality
 # batch_size = 128                       # Texts per batch request
 # timeout = "120s"                       # HTTP timeout per request
+# query_prefix = "search_query: "        # Task prefix for query embedding (nomic-embed-text)
+# document_prefix = "search_document: "  # Task prefix for document embedding (nomic-embed-text)
 
 [test]
 # patterns = ["*_test.go", "testdata/"]  # Glob patterns identifying test files

--- a/internal/types/interfaces.go
+++ b/internal/types/interfaces.go
@@ -35,8 +35,10 @@ type MetadataStore interface {
 	InsertSymbols(ctx context.Context, fileID int64, symbols []SymbolRecord) ([]int64, error)
 	// GetSymbolsByFile returns all symbols for a file.
 	GetSymbolsByFile(ctx context.Context, fileID int64) ([]SymbolRecord, error)
-	// GetSymbolByName returns symbols matching the given name.
+	// GetSymbolByName returns symbols matching the given name (case-sensitive).
 	GetSymbolByName(ctx context.Context, name string) ([]SymbolRecord, error)
+	// GetSymbolByNameCI returns symbols matching the given name case-insensitively.
+	GetSymbolByNameCI(ctx context.Context, name string) ([]SymbolRecord, error)
 	// GetSymbolByID returns a single symbol by its ID.
 	GetSymbolByID(ctx context.Context, id int64) (*SymbolRecord, error)
 	// DeleteSymbolsByFile removes all symbols for a file.

--- a/internal/vector/embed_worker.go
+++ b/internal/vector/embed_worker.go
@@ -20,23 +20,25 @@ type EmbedJob struct {
 
 // EmbedWorkerInput configures the EmbedWorker.
 type EmbedWorkerInput struct {
-	Store       types.VectorStore
-	Embedder    *OllamaClient
-	BatchSize   int
-	OnBatchDone func(chunkIDs []int64) // optional callback after successful upsert
+	Store          types.VectorStore
+	Embedder       *OllamaClient
+	BatchSize      int
+	OnBatchDone    func(chunkIDs []int64) // optional callback after successful upsert
+	DocumentPrefix string                 // prepended to chunk content before embedding (e.g. "search_document: ")
 }
 
 // EmbedWorker processes embedding jobs in batches with circuit breaker protection.
 type EmbedWorker struct {
-	store       types.VectorStore
-	embedder    *OllamaClient
-	cb          *CircuitBreaker
-	queue       chan EmbedJob
-	batchSz     int
-	logger      *slog.Logger
-	onBatchDone func(chunkIDs []int64)
-	dropped     atomic.Int64
-	inflight    sync.WaitGroup // tracks in-flight processBatch calls
+	store          types.VectorStore
+	embedder       *OllamaClient
+	cb             *CircuitBreaker
+	queue          chan EmbedJob
+	batchSz        int
+	logger         *slog.Logger
+	onBatchDone    func(chunkIDs []int64)
+	dropped        atomic.Int64
+	inflight       sync.WaitGroup // tracks in-flight processBatch calls
+	documentPrefix string         // prepended to chunk content before embedding
 }
 
 // NewEmbedWorker creates an embedding worker.
@@ -46,13 +48,14 @@ func NewEmbedWorker(input EmbedWorkerInput) *EmbedWorker {
 		batchSz = 128
 	}
 	return &EmbedWorker{
-		store:       input.Store,
-		embedder:    input.Embedder,
-		cb:          NewCircuitBreaker(),
-		queue:       make(chan EmbedJob, 1000),
-		batchSz:     batchSz,
-		logger:      slog.Default().With("component", "embed-worker"),
-		onBatchDone: input.OnBatchDone,
+		store:          input.Store,
+		embedder:       input.Embedder,
+		cb:             NewCircuitBreaker(),
+		queue:          make(chan EmbedJob, 1000),
+		batchSz:        batchSz,
+		logger:         slog.Default().With("component", "embed-worker"),
+		onBatchDone:    input.OnBatchDone,
+		documentPrefix: input.DocumentPrefix,
 	}
 }
 
@@ -159,7 +162,7 @@ func (w *EmbedWorker) processBatch(ctx context.Context, batch []EmbedJob) {
 
 	texts := make([]string, len(batch))
 	for i, j := range batch {
-		texts[i] = j.Content
+		texts[i] = w.documentPrefix + j.Content
 	}
 
 	vectors, err := w.embedder.EmbedBatch(ctx, texts)
@@ -332,7 +335,7 @@ func (w *EmbedWorker) reconcileAndEmbed(ctx context.Context, source types.EmbedS
 	texts := make([]string, len(needEmbed))
 	needIDs := make([]int64, len(needEmbed))
 	for j, job := range needEmbed {
-		texts[j] = job.Content
+		texts[j] = w.documentPrefix + job.Content
 		needIDs[j] = job.ChunkID
 	}
 
@@ -473,7 +476,7 @@ func (w *EmbedWorker) retryDeferred(ctx context.Context, rs *runState) error {
 				continue
 			}
 
-			vecs, err := w.embedder.EmbedBatch(ctx, []string{dc.job.Content})
+			vecs, err := w.embedder.EmbedBatch(ctx, []string{w.documentPrefix + dc.job.Content})
 			if err != nil {
 				if errors.Is(err, ErrPermanentEmbed) {
 					rs.skipped++


### PR DESCRIPTION
 Commit 1: fix: correct semantic search for identifier queries
                                                                                                                                                                                                                                                                                                                                                                        
  Root cause: shaktiman search buildBuyerOptions returned mandrill_mailer.rb at #1 (score 0.608) instead of the actual function definitions. Two bugs caused this:                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                                                                        
  1. Missing nomic-embed-text task prefixes — Documents were embedded without search_document:  and queries without search_query: . Without these prefixes, the contrastive training breaks down and the model assigns near-perfect cosine similarity to random short strings.                                                                                          
  2. No identifier-aware lookup — camelCase/snake_case queries went through the full hybrid ranker instead of directly querying the symbols table.                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                                        
  Files changed:                                                                                                                                                                                                                                                                                                                                                        
  - internal/types/config.go — Added EmbedQueryPrefix / EmbedDocumentPrefix config fields (defaults: "search_query: " / "search_document: ")                                                                                                                                                                                                                            
  - internal/vector/embed_worker.go — Apply DocumentPrefix when embedding each chunk                                                                                                                                                                                                                                                                                    
  - internal/daemon/daemon.go — Wire both prefixes into the embed worker and query engine                                                                                                                                                                                                                                                                             
  - internal/core/engine.go — Add queryPrefix field; prepend it before embedding queries; integrate SymbolExactSearch into both searchSemantic and searchKeyword                                                                                                                                                                                                        
  - internal/core/lookup.go — New file: isIdentifierQuery() + SymbolExactSearch() (case-sensitive → CI fallback, score=1.0)                                                                                                                                                                                                                                             
  - internal/types/interfaces.go — Added GetSymbolByNameCI to MetadataStore interface                                                                                                                                                                                                                                                                                   
  - internal/storage/sqlite/metadata.go — GetSymbolByNameCI via COLLATE NOCASE                                                                                                                                                                                                                                                                                          
  - internal/storage/postgres/metadata.go — GetSymbolByNameCI via ILIKE                                                                                                                                                                                                                                                                                                 
  - internal/storage/sqlite/fts.go — Fix sanitizeFTSQuery to handle trailing *                                                                                                                                                                                                                                                                                          
  - cmd/shaktiman/main.go — Added re-embed command (deletes embeddings.bin, resets embedded flags)                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                                        
  ---                                                                                                                                                                                                                                                                                                                                                                   
  Commit 2: fix: eliminate hub-noise from identifier searches                                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                                                                        
  Root cause: Even after commit 1, unrelated results appeared at score ~0.47 because:                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                                                                        
  1. openEngine in query.go (used by all CLI commands) never called SetQueryPrefix — only the daemon did. So CLI queries were embedded without the task prefix.                                                                                                                                                                                                         
  2. Even with correct prefixes, nomic-embed-text assigns cosine ~0.74 to any short code snippet against a camelCase query (short-string hubness is intrinsic to this model). Appending hybrid results after exact matches just added noise.                                                                                                                            
                                                                                                                                                                                                                                                                                                                                                                        
  Files changed:                                                                                                                                                                                                                                                                                                                                                      
  - cmd/shaktiman/query.go — Added engine.SetQueryPrefix(cfg.EmbedQueryPrefix) in openEngine                                                                                                                                                                                                                                                                            
  - internal/core/engine.go — When exact symbol matches exist for an identifier query, return only those — drop the hybrid tail entirely                                                                                                                                                                                                                                
                                                                                                                                        
  Result:                                                                                                                                                                                                                                                                                                                                                               
  # Before                                                                                                                                                                                                                                                                                                                                                              
  mandrill_mailer.rb  score:0.608  ← wrong, position #1                                                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                                                                        
  # After                                                                                                                                                                                                                                                                                                                                                               
  buildRoutesPayload  score:1.00   ← correct, only result