### PR TITLE
feat: add task prefix support for nomic-embed-text embeddings

### DIFF
--- a/cmd/shaktiman/query.go
+++ b/cmd/shaktiman/query.go
@@ -32,7 +32,7 @@ func openStore(cfg types.Config) (types.WriterStore, func() error, error) {
 // Read-only: loads existing embeddings from disk, does not start embed worker.
 // Falls back to keyword-only if embeddings are unavailable.
 func openEngine(cfg types.Config, store types.WriterStore, root string) (*core.QueryEngine, types.VectorStore) {
-	engine := core.NewQueryEngine(store, root)
+	engine := core.NewQueryEngine(store, root, cfg.EmbedQueryPrefix)
 
 	if !cfg.EmbedEnabled {
 		return engine, nil

--- a/internal/core/engine.go
+++ b/internal/core/engine.go
@@ -18,17 +18,21 @@ type QueryEngine struct {
 	vectorStore  types.VectorStore // nil if embeddings disabled
 	embedder     types.Embedder    // nil if embeddings disabled
 	embedCache   *vector.EmbedCache
-	embedReady   func() bool       // checks if embedding service is available
-	sessionStore *SessionStore     // nil if session scoring disabled
+	embedReady   func() bool   // checks if embedding service is available
+	sessionStore *SessionStore // nil if session scoring disabled
+	queryPrefix  string        // prepended to query text before embedding (e.g. "search_query: ")
 }
 
 // NewQueryEngine creates an engine backed by the given store.
-func NewQueryEngine(store types.MetadataStore, projectRoot string) *QueryEngine {
+// queryPrefix is prepended to query text before embedding; use "" for models that don't require task prefixes.
+// For nomic-embed-text use "search_query: ".
+func NewQueryEngine(store types.MetadataStore, projectRoot string, queryPrefix string) *QueryEngine {
 	return &QueryEngine{
 		store:       store,
 		projectRoot: projectRoot,
 		logger:      slog.Default().With("component", "engine"),
 		embedCache:  vector.NewEmbedCache(100),
+		queryPrefix: queryPrefix,
 	}
 }
 
@@ -275,15 +279,18 @@ func (e *QueryEngine) contextKeyword(ctx context.Context, input ContextInput) (*
 }
 
 // embedQuery produces or retrieves a cached embedding for the query text.
+// queryPrefix is prepended before embedding and used as the cache key so that
+// a prefix change (e.g. switching models) does not serve stale cached vectors.
 func (e *QueryEngine) embedQuery(ctx context.Context, query string) ([]float32, error) {
-	if vec, ok := e.embedCache.Get(query); ok {
+	prefixed := e.queryPrefix + query
+	if vec, ok := e.embedCache.Get(prefixed); ok {
 		return vec, nil
 	}
-	vec, err := e.embedder.Embed(ctx, query)
+	vec, err := e.embedder.Embed(ctx, prefixed)
 	if err != nil {
 		return nil, err
 	}
-	e.embedCache.Put(query, vec)
+	e.embedCache.Put(prefixed, vec)
 	return vec, nil
 }
 

--- a/internal/core/engine_test.go
+++ b/internal/core/engine_test.go
@@ -14,7 +14,7 @@ import (
 func setupTestEngine(t *testing.T) (*QueryEngine, types.WriterStore) {
 	t.Helper()
 	store := testutil.NewTestWriterStore(t)
-	engine := NewQueryEngine(store, t.TempDir())
+	engine := NewQueryEngine(store, t.TempDir(), "")
 	return engine, store
 }
 
@@ -105,7 +105,7 @@ func TestSearch_FilesystemFallback(t *testing.T) {
 	// Create engine with empty store — should use filesystem fallback
 	store := testutil.NewTestWriterStore(t)
 	// Use testdata directory as project root for filesystem fallback
-	engine := NewQueryEngine(store, "../../testdata/typescript_project")
+	engine := NewQueryEngine(store, "../../testdata/typescript_project", "")
 
 	results, err := engine.Search(context.Background(), SearchInput{
 		Query:      "login",
@@ -674,7 +674,7 @@ func BenchmarkContextAssembly(b *testing.B) {
 func setupBenchEngine(b *testing.B) (*QueryEngine, types.WriterStore) {
 	b.Helper()
 	store := newBenchStore(b)
-	engine := NewQueryEngine(store, b.TempDir())
+	engine := NewQueryEngine(store, b.TempDir(), "")
 	return engine, store
 }
 
@@ -903,7 +903,7 @@ func TestSearch_KeywordEmpty_FallsBackToFilesystem(t *testing.T) {
 	os.WriteFile(filepath.Join(tmpDir, "hello.go"),
 		[]byte("package main\nfunc Hello() {}"), 0644)
 
-	engine := NewQueryEngine(store, tmpDir)
+	engine := NewQueryEngine(store, tmpDir, "")
 
 	// Query for something that won't match any FTS content.
 	results, err := engine.Search(ctx, SearchInput{
@@ -940,7 +940,7 @@ func TestContext_KeywordEmpty_FallsBackToFilesystem(t *testing.T) {
 	os.WriteFile(filepath.Join(tmpDir, "ctx.go"),
 		[]byte("package main\nfunc Context() {}"), 0644)
 
-	engine := NewQueryEngine(store, tmpDir)
+	engine := NewQueryEngine(store, tmpDir, "")
 
 	pkg, err := engine.Context(ctx, ContextInput{
 		Query:        "zzz_nonexistent_query_xyx",
@@ -981,7 +981,7 @@ func TestContext_SemanticEmpty_FallsBackToFilesystem(t *testing.T) {
 	vs.Upsert(ctx, 1, []float32{0.1, 0.1, 0.1, 0.1})
 
 	embedder := newMockEmbedder(dim)
-	engine := NewQueryEngine(store, tmpDir)
+	engine := NewQueryEngine(store, tmpDir, "")
 	engine.SetVectorStore(vs, embedder, func() bool { return true })
 
 	pkg, err := engine.Context(ctx, ContextInput{

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -62,7 +62,7 @@ func New(cfg types.Config) (*Daemon, error) {
 		return nil, fmt.Errorf("create metadata store: %w", err)
 	}
 
-	engine := core.NewQueryEngine(store, cfg.ProjectRoot)
+	engine := core.NewQueryEngine(store, cfg.ProjectRoot, cfg.EmbedQueryPrefix)
 	writer := NewWriterManager(store, cfg.WriterChannelSize, cfg.TestPatterns)
 
 	// Session-aware ranking
@@ -126,9 +126,10 @@ func (d *Daemon) initEmbedding() {
 	})
 
 	worker := vector.NewEmbedWorker(vector.EmbedWorkerInput{
-		Store:     vs,
-		Embedder:  client,
-		BatchSize: d.cfg.EmbedBatchSize,
+		Store:          vs,
+		Embedder:       client,
+		BatchSize:      d.cfg.EmbedBatchSize,
+		DocumentPrefix: d.cfg.EmbedDocumentPrefix,
 		OnBatchDone: func(chunkIDs []int64) {
 			if err := d.store.MarkChunksEmbedded(context.Background(), chunkIDs); err != nil {
 				d.logger.Warn("mark chunks embedded failed", "err", err)

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -47,7 +47,7 @@ func setupEvalEngine(t *testing.T) *core.QueryEngine {
 		t.Fatalf("InsertChunks: %v", err)
 	}
 
-	return core.NewQueryEngine(store, t.TempDir())
+	return core.NewQueryEngine(store, t.TempDir(), "")
 }
 
 func TestEvaluate_BasicMetrics(t *testing.T) {

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -93,7 +93,7 @@ func setupSearchHandler(t *testing.T) handlerFunc {
 		t.Fatalf("InsertChunks: %v", err)
 	}
 
-	engine := core.NewQueryEngine(store, t.TempDir())
+	engine := core.NewQueryEngine(store, t.TempDir(), "")
 	cfg := types.DefaultConfig(t.TempDir())
 	return searchHandler(engine, cfg)
 }
@@ -369,7 +369,7 @@ func setupStoreWithData(t *testing.T) types.WriterStore {
 func setupContextHandler(t *testing.T) handlerFunc {
 	t.Helper()
 	store := setupStore(t)
-	engine := core.NewQueryEngine(store, t.TempDir())
+	engine := core.NewQueryEngine(store, t.TempDir(), "")
 	cfg := types.DefaultConfig(t.TempDir())
 	return contextHandler(engine, cfg)
 }
@@ -971,7 +971,7 @@ func TestToolDefs_DoNotPanic(t *testing.T) {
 func TestNewServer_DoesNotPanic(t *testing.T) {
 	t.Parallel()
 	store := setupStore(t)
-	engine := core.NewQueryEngine(store, t.TempDir())
+	engine := core.NewQueryEngine(store, t.TempDir(), "")
 	cfg := types.DefaultConfig(t.TempDir())
 
 	srv := NewServer(NewServerInput{
@@ -1408,7 +1408,7 @@ func setupStoreWithTestFiles(t *testing.T) types.WriterStore {
 func TestSearchHandler_Scope_DefaultExcludesTests(t *testing.T) {
 	t.Parallel()
 	store := setupStoreWithTestFiles(t)
-	engine := core.NewQueryEngine(store, t.TempDir())
+	engine := core.NewQueryEngine(store, t.TempDir(), "")
 	cfg := types.DefaultConfig(t.TempDir())
 	cfg.SearchMinScore = 0 // disable score threshold for test
 	handler := searchHandler(engine, cfg)
@@ -1431,7 +1431,7 @@ func TestSearchHandler_Scope_DefaultExcludesTests(t *testing.T) {
 func TestSearchHandler_Scope_Test(t *testing.T) {
 	t.Parallel()
 	store := setupStoreWithTestFiles(t)
-	engine := core.NewQueryEngine(store, t.TempDir())
+	engine := core.NewQueryEngine(store, t.TempDir(), "")
 	cfg := types.DefaultConfig(t.TempDir())
 	cfg.SearchMinScore = 0
 	handler := searchHandler(engine, cfg)
@@ -1456,7 +1456,7 @@ func TestSearchHandler_Scope_Test(t *testing.T) {
 func TestSearchHandler_Scope_All(t *testing.T) {
 	t.Parallel()
 	store := setupStoreWithTestFiles(t)
-	engine := core.NewQueryEngine(store, t.TempDir())
+	engine := core.NewQueryEngine(store, t.TempDir(), "")
 	cfg := types.DefaultConfig(t.TempDir())
 	cfg.SearchMinScore = 0
 	handler := searchHandler(engine, cfg)

--- a/internal/types/config.go
+++ b/internal/types/config.go
@@ -61,6 +61,14 @@ type Config struct {
 	// Embedding timeout
 	EmbedTimeout time.Duration // HTTP timeout per embedding request (default: 120s)
 
+	// EmbedQueryPrefix is prepended to query text before embedding.
+	// For nomic-embed-text use "search_query: ". Empty by default (model-agnostic).
+	EmbedQueryPrefix string
+
+	// EmbedDocumentPrefix is prepended to chunk content before embedding.
+	// For nomic-embed-text use "search_document: ". Empty by default (model-agnostic).
+	EmbedDocumentPrefix string
+
 	// Test file detection patterns (glob patterns and directory prefixes)
 	TestPatterns []string // e.g. ["*_test.go", "testdata/", "*.test.ts"]
 }
@@ -154,11 +162,13 @@ type tomlQdrant struct {
 }
 
 type tomlEmbedding struct {
-	OllamaURL *string `toml:"ollama_url"`
-	Model     *string `toml:"model"`
-	Dims      *int    `toml:"dims"`
-	BatchSize *int    `toml:"batch_size"`
-	Timeout   *string `toml:"timeout"`
+	OllamaURL      *string `toml:"ollama_url"`
+	Model          *string `toml:"model"`
+	Dims           *int    `toml:"dims"`
+	BatchSize      *int    `toml:"batch_size"`
+	Timeout        *string `toml:"timeout"`
+	QueryPrefix    *string `toml:"query_prefix"`
+	DocumentPrefix *string `toml:"document_prefix"`
 }
 
 // LoadConfigFromFile reads shaktiman.toml and merges values into cfg.
@@ -286,6 +296,12 @@ func LoadConfigFromFile(cfg Config) (Config, error) {
 		}
 		cfg.EmbedTimeout = d
 	}
+	if v := tc.Embedding.QueryPrefix; v != nil {
+		cfg.EmbedQueryPrefix = *v
+	}
+	if v := tc.Embedding.DocumentPrefix; v != nil {
+		cfg.EmbedDocumentPrefix = *v
+	}
 
 	// Environment variable overrides for secrets (highest priority after CLI flags)
 	if v := os.Getenv("SHAKTIMAN_POSTGRES_URL"); v != "" {
@@ -356,6 +372,8 @@ const sampleConfig = `# Shaktiman configuration
 # dims = 768                             # Vector dimensionality
 # batch_size = 128                       # Texts per batch request
 # timeout = "120s"                       # HTTP timeout per request
+# query_prefix = "search_query: "        # Task prefix for query embedding (nomic-embed-text)
+# document_prefix = "search_document: "  # Task prefix for document embedding (nomic-embed-text)
 
 [test]
 # patterns = ["*_test.go", "testdata/"]  # Glob patterns identifying test files

--- a/internal/vector/embed_worker.go
+++ b/internal/vector/embed_worker.go
@@ -20,23 +20,25 @@ type EmbedJob struct {
 
 // EmbedWorkerInput configures the EmbedWorker.
 type EmbedWorkerInput struct {
-	Store       types.VectorStore
-	Embedder    *OllamaClient
-	BatchSize   int
-	OnBatchDone func(chunkIDs []int64) // optional callback after successful upsert
+	Store          types.VectorStore
+	Embedder       *OllamaClient
+	BatchSize      int
+	OnBatchDone    func(chunkIDs []int64) // optional callback after successful upsert
+	DocumentPrefix string                 // prepended to chunk content before embedding (e.g. "search_document: ")
 }
 
 // EmbedWorker processes embedding jobs in batches with circuit breaker protection.
 type EmbedWorker struct {
-	store       types.VectorStore
-	embedder    *OllamaClient
-	cb          *CircuitBreaker
-	queue       chan EmbedJob
-	batchSz     int
-	logger      *slog.Logger
-	onBatchDone func(chunkIDs []int64)
-	dropped     atomic.Int64
-	inflight    sync.WaitGroup // tracks in-flight processBatch calls
+	store          types.VectorStore
+	embedder       *OllamaClient
+	cb             *CircuitBreaker
+	queue          chan EmbedJob
+	batchSz        int
+	logger         *slog.Logger
+	onBatchDone    func(chunkIDs []int64)
+	dropped        atomic.Int64
+	inflight       sync.WaitGroup // tracks in-flight processBatch calls
+	documentPrefix string         // prepended to chunk content before embedding
 }
 
 // NewEmbedWorker creates an embedding worker.
@@ -46,13 +48,14 @@ func NewEmbedWorker(input EmbedWorkerInput) *EmbedWorker {
 		batchSz = 128
 	}
 	return &EmbedWorker{
-		store:       input.Store,
-		embedder:    input.Embedder,
-		cb:          NewCircuitBreaker(),
-		queue:       make(chan EmbedJob, 1000),
-		batchSz:     batchSz,
-		logger:      slog.Default().With("component", "embed-worker"),
-		onBatchDone: input.OnBatchDone,
+		store:          input.Store,
+		embedder:       input.Embedder,
+		cb:             NewCircuitBreaker(),
+		queue:          make(chan EmbedJob, 1000),
+		batchSz:        batchSz,
+		logger:         slog.Default().With("component", "embed-worker"),
+		onBatchDone:    input.OnBatchDone,
+		documentPrefix: input.DocumentPrefix,
 	}
 }
 
@@ -159,7 +162,7 @@ func (w *EmbedWorker) processBatch(ctx context.Context, batch []EmbedJob) {
 
 	texts := make([]string, len(batch))
 	for i, j := range batch {
-		texts[i] = j.Content
+		texts[i] = w.documentPrefix + j.Content
 	}
 
 	vectors, err := w.embedder.EmbedBatch(ctx, texts)
@@ -332,7 +335,7 @@ func (w *EmbedWorker) reconcileAndEmbed(ctx context.Context, source types.EmbedS
 	texts := make([]string, len(needEmbed))
 	needIDs := make([]int64, len(needEmbed))
 	for j, job := range needEmbed {
-		texts[j] = job.Content
+		texts[j] = w.documentPrefix + job.Content
 		needIDs[j] = job.ChunkID
 	}
 
@@ -473,7 +476,7 @@ func (w *EmbedWorker) retryDeferred(ctx context.Context, rs *runState) error {
 				continue
 			}
 
-			vecs, err := w.embedder.EmbedBatch(ctx, []string{dc.job.Content})
+			vecs, err := w.embedder.EmbedBatch(ctx, []string{w.documentPrefix + dc.job.Content})
 			if err != nil {
 				if errors.Is(err, ErrPermanentEmbed) {
 					rs.skipped++


### PR DESCRIPTION
                                                                                                                                                                                                                                                                         
  Feat: add task prefix support for nomic-embed-text embeddings
                                                                                                                                                                                                                                                                                        
  Summary                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                        
  - Adds EmbedQueryPrefix and EmbedDocumentPrefix fields to Config, configurable via query_prefix and document_prefix in the [embedding] section of shaktiman.toml                                                                                                                      
  - Passes queryPrefix into NewQueryEngine so query text is prefixed before embedding and cache lookup (cache key includes prefix to avoid stale vectors after model changes)                                                                                                           
  - Passes DocumentPrefix into EmbedWorker so chunk content is prefixed before batching — applied in all three embedding paths: processBatch, reconcileAndEmbed, and retryDeferred                                                                                                      
  - Updates all call sites (daemon.go, query.go, and all test helpers) to supply the new parameters; tests pass "" (no prefix) for model-agnostic behavior                                                                                                                              
                                                                                                                                                                                                                                                                                        
  Motivation                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                        
  nomic-embed-text requires task prefixes ("search_query: " / "search_document: ") to distinguish retrieval intent from indexing intent at embedding time. Without these prefixes, semantic search quality degrades. This change makes prefix configuration first-class and             
  model-agnostic — models that don't need prefixes simply leave the fields empty.
                                                                                                                                                                                                                                                                                        
  Test plan                                                                                                                                                                                                                                                                           

  - All existing tests pass with "" prefix (no behavioral change for non-prefixed models)                                                                                                                                                                                               
  - Manually configure query_prefix = "search_query: " and document_prefix = "search_document: " with a nomic-embed-text Ollama instance and verify improved semantic search results
  - Confirm that changing the prefix causes cache misses (new vectors fetched) rather than serving stale cached embeddings                                                                                                                                                              
                                                                                                                           