### PR TITLE
Batch 2 correctness fixes

### DIFF
--- a/internal/daemon/writer.go
+++ b/internal/daemon/writer.go
@@ -315,15 +315,21 @@ func processEnrichmentJob(ctx context.Context, store types.WriterStore, logger *
 		}
 	}
 
-	// Insert symbols with resolved chunk IDs, track name->ID mapping for edges
-	symRecords := make([]types.SymbolRecord, len(job.Symbols))
+	// Insert symbols with resolved chunk IDs, track name->ID mapping for edges.
+	// findContainingChunk returns -1 for symbols whose line doesn't fall
+	// inside any chunk. Previously these were silently mis-attributed to
+	// chunk 0 (often the file header). Skip them here and record only the
+	// valid ones; emit a Debug log so the count is observable under load.
+	symRecords := make([]types.SymbolRecord, 0, len(job.Symbols))
+	validSymIdx := make([]int, 0, len(job.Symbols)) // parser-side index for each accepted record
+	var orphanCount int
 	for i, sym := range job.Symbols {
-		chunkID := int64(0)
-		if int(sym.ChunkID) < len(chunkIDs) {
-			chunkID = chunkIDs[sym.ChunkID]
+		if sym.ChunkID < 0 || int(sym.ChunkID) >= len(chunkIDs) {
+			orphanCount++
+			continue
 		}
-		symRecords[i] = types.SymbolRecord{
-			ChunkID:       chunkID,
+		symRecords = append(symRecords, types.SymbolRecord{
+			ChunkID:       chunkIDs[sym.ChunkID],
 			Name:          sym.Name,
 			QualifiedName: sym.QualifiedName,
 			Kind:          sym.Kind,
@@ -331,16 +337,22 @@ func processEnrichmentJob(ctx context.Context, store types.WriterStore, logger *
 			Signature:     sym.Signature,
 			Visibility:    sym.Visibility,
 			IsExported:    sym.IsExported,
-		}
+		})
+		validSymIdx = append(validSymIdx, i)
+	}
+	if orphanCount > 0 {
+		slog.Debug("orphan symbols skipped (no containing chunk)",
+			"file", job.FilePath, "count", orphanCount, "total", len(job.Symbols))
 	}
 	symIDs, err := store.InsertSymbols(ctx, fileID, symRecords)
 	if err != nil {
 		return nil, fmt.Errorf("insert symbols for %s: %w", job.FilePath, err)
 	}
 
-	symbolIDs := make(map[string]int64, len(job.Symbols))
+	symbolIDs := make(map[string]int64, len(symRecords))
 	var newSymbolNames []string
-	for i, sym := range job.Symbols {
+	for i := range symRecords {
+		sym := job.Symbols[validSymIdx[i]]
 		// Keep the first symbol ID for each name. Duplicates (e.g. Java
 		// method overloads) would overwrite, potentially pointing edges
 		// at the wrong overload.

--- a/internal/parser/chunker.go
+++ b/internal/parser/chunker.go
@@ -17,6 +17,14 @@ const minChunkTokens = 20
 // maxChunkDepth prevents unbounded recursion on pathological ASTs.
 const maxChunkDepth = 10
 
+// maxASTDepth bounds traversal through non-chunkable structural nodes
+// (block, body_statement, declaration_list, class_body, etc.) inside
+// findChunkableChildren. The chunkable-depth guard only fires when
+// chunkNode is called, so pathologically-nested structural chains
+// between chunkables could drive the Go stack into overflow. 200 is
+// comfortably above any realistic code nesting.
+const maxASTDepth = 200
+
 // ChunkAlgorithmVersion identifies the current chunking algorithm. Bump this
 // whenever chunk boundaries, signature format, or traversal semantics change
 // in a way that would make previously indexed chunks incompatible or
@@ -198,7 +206,7 @@ func (p *Parser) chunkNode(node *tree_sitter.Node, source []byte, cfg *LanguageC
 
 	// Node exceeds maxChunkTokens — try to decompose via chunkable descendants.
 	var extracted []types.ChunkRecord
-	p.findChunkableChildren(node, source, cfg, depth, &extracted)
+	p.findChunkableChildren(node, source, cfg, depth, 0, &extracted)
 
 	if len(extracted) > 0 {
 		// Parent becomes a signature chunk
@@ -233,7 +241,20 @@ func (p *Parser) chunkNode(node *tree_sitter.Node, source []byte, cfg *LanguageC
 // descendants) to find chunkable nodes. This traverses through non-chunkable
 // structural nodes (body_statement, block, declaration_list, class_body, etc.)
 // to reach the chunkable leaves.
-func (p *Parser) findChunkableChildren(node *tree_sitter.Node, source []byte, cfg *LanguageConfig, depth int, extracted *[]types.ChunkRecord) {
+//
+// chunkDepth is the chunkable-container depth passed through to chunkNode on
+// a match (bounded by maxChunkDepth). astDepth is the raw recursion depth
+// through structural nodes and is independent of chunkable depth — it
+// protects against pathologically-nested ASTs that would otherwise overflow
+// the Go stack via this function's structural recursion.
+func (p *Parser) findChunkableChildren(node *tree_sitter.Node, source []byte, cfg *LanguageConfig, chunkDepth int, astDepth int, extracted *[]types.ChunkRecord) {
+	if astDepth > maxASTDepth {
+		if p.logger != nil {
+			p.logger.Warn("parser AST depth guard triggered; stopping descent",
+				"file", p.curPath, "depth", astDepth, "max", maxASTDepth)
+		}
+		return
+	}
 	childCount := int(node.NamedChildCount()) //nolint:gosec // tree-sitter NamedChildCount is uint32, fits int on 64-bit
 	for i := 0; i < childCount; i++ {
 		child := node.NamedChild(uint(i))
@@ -261,11 +282,13 @@ func (p *Parser) findChunkableChildren(node *tree_sitter.Node, source []byte, cf
 		}
 
 		if _, chunkable := cfg.ChunkableTypes[childType]; chunkable {
-			*extracted = append(*extracted, p.chunkNode(child, source, cfg, depth+1)...)
+			*extracted = append(*extracted, p.chunkNode(child, source, cfg, chunkDepth+1)...)
 		} else {
 			// Recurse through structural nodes (body_statement, block,
-			// declaration_list, class_body, etc.) to find nested chunkables
-			p.findChunkableChildren(child, source, cfg, depth, extracted)
+			// declaration_list, class_body, etc.) to find nested chunkables.
+			// astDepth+1 so pathologically-deep structural chains hit the
+			// guard before we overflow the Go stack.
+			p.findChunkableChildren(child, source, cfg, chunkDepth, astDepth+1, extracted)
 		}
 	}
 }

--- a/internal/parser/edges.go
+++ b/internal/parser/edges.go
@@ -13,7 +13,7 @@ type edgeContext struct {
 	source      []byte
 	cfg         *LanguageConfig
 	edges       []types.EdgeRecord
-	seen        map[string]bool // "src|dst|kind" dedup
+	seen        map[string]bool // "src|dst|qualifiedDst|kind" dedup
 	importOwner string          // fallback owner for file-level imports
 }
 
@@ -25,7 +25,11 @@ func (c *edgeContext) addEdgeQualified(src, dst, qualifiedDst, kind string) {
 	if dst == "" {
 		return
 	}
-	key := src + "|" + dst + "|" + kind
+	// Dedup key includes qualifiedDst so two imports of the same short name
+	// from different modules (e.g. `import Foo from 'a'` and
+	// `from b import Foo`) produce two distinct edges, not one collapsed
+	// record where only the first qualified path survives.
+	key := src + "|" + dst + "|" + qualifiedDst + "|" + kind
 	if c.seen[key] {
 		return
 	}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -60,7 +60,25 @@ type ParseResult struct {
 }
 
 // Parse parses a source file and returns chunks, symbols, and edges.
-func (p *Parser) Parse(ctx context.Context, input ParseInput) (*ParseResult, error) {
+//
+// Contains defer/recover around the tree-sitter CGO call chain and the
+// downstream AST walkers: a grammar panic on malformed input (known class
+// of tree-sitter crashes) would otherwise kill the worker goroutine and
+// take down the daemon. On recovery we return an error so the caller can
+// log-and-skip the file.
+func (p *Parser) Parse(ctx context.Context, input ParseInput) (_ *ParseResult, retErr error) {
+	defer func() {
+		if r := recover(); r != nil {
+			if p.logger != nil {
+				p.logger.Error("parser panic recovered",
+					"file", input.FilePath,
+					"language", input.Language,
+					"panic", fmt.Sprint(r))
+			}
+			retErr = fmt.Errorf("parser panic on %s (lang=%s): %v", input.FilePath, input.Language, r)
+		}
+	}()
+
 	p.curPath = input.FilePath
 	cfg, err := p.getConfig(input.Language)
 	if err != nil {

--- a/internal/parser/robustness_test.go
+++ b/internal/parser/robustness_test.go
@@ -1,0 +1,115 @@
+package parser
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/shaktimanai/shaktiman/internal/types"
+)
+
+// TestFindContainingChunk_ReturnsMinusOneOnMiss verifies the sentinel-value
+// contract. Previously the function returned 0 for both "line is in chunk 0"
+// and "line is in no chunk", silently mis-attributing orphan symbols to the
+// header chunk.
+func TestFindContainingChunk_ReturnsMinusOneOnMiss(t *testing.T) {
+	t.Parallel()
+
+	chunks := []types.ChunkRecord{
+		{StartLine: 1, EndLine: 10},
+		{StartLine: 11, EndLine: 20},
+	}
+
+	// In-range cases.
+	if got := findContainingChunk(5, chunks); got != 0 {
+		t.Errorf("line 5 should hit chunk 0; got %d", got)
+	}
+	if got := findContainingChunk(15, chunks); got != 1 {
+		t.Errorf("line 15 should hit chunk 1; got %d", got)
+	}
+
+	// Miss cases must now return -1, not 0.
+	if got := findContainingChunk(25, chunks); got != -1 {
+		t.Errorf("line 25 (no chunk) should return -1; got %d", got)
+	}
+	if got := findContainingChunk(0, chunks); got != -1 {
+		t.Errorf("line 0 (before any chunk) should return -1; got %d", got)
+	}
+	if got := findContainingChunk(0, nil); got != -1 {
+		t.Errorf("no chunks at all should return -1; got %d", got)
+	}
+}
+
+// TestParse_RecoverFromPanic verifies that a panic inside the parser pipeline
+// is caught and converted to an error instead of taking down the goroutine.
+// We exercise the recover path by forcing a panic via an injected token
+// counter (easiest entry point without mocking the grammar itself).
+func TestParse_RecoverFromPanic(t *testing.T) {
+	t.Parallel()
+
+	p, err := NewParser()
+	if err != nil {
+		t.Fatalf("NewParser: %v", err)
+	}
+	defer p.Close()
+
+	// Replace the token counter with one that panics on any call.
+	// Parse invokes tokens.Count inside chunkFile; this exercises the
+	// recover at the top of Parse.
+	p.tokens = &tokenCounter{} // zero-value counter — its internal fields are nil
+	// Zero-value tokenCounter panics on Count because its encoder is nil.
+
+	_, parseErr := p.Parse(context.Background(), ParseInput{
+		FilePath: "test.go",
+		Content:  []byte("package main\nfunc F() {}\n"),
+		Language: "go",
+	})
+	if parseErr == nil {
+		t.Fatalf("expected error from recovered panic, got nil")
+	}
+	if !strings.Contains(parseErr.Error(), "panic") {
+		t.Errorf("error should mention panic recovery, got: %v", parseErr)
+	}
+}
+
+// TestEdges_DedupIncludesQualifiedDst verifies that two imports of the same
+// short name from different modules produce two distinct edges, not one.
+// Pre-fix, the dedup key was src|dst|kind and silently collapsed them,
+// discarding the second qualified path.
+func TestEdges_DedupIncludesQualifiedDst(t *testing.T) {
+	t.Parallel()
+
+	ctx := &edgeContext{
+		seen: make(map[string]bool),
+	}
+	ctx.addEdgeQualified("main", "Foo", "pkg_a.Foo", "imports")
+	ctx.addEdgeQualified("main", "Foo", "pkg_b.Foo", "imports")
+
+	if len(ctx.edges) != 2 {
+		t.Fatalf("expected 2 edges for different qualified paths, got %d: %+v", len(ctx.edges), ctx.edges)
+	}
+	qualified := map[string]bool{
+		ctx.edges[0].DstQualifiedName: true,
+		ctx.edges[1].DstQualifiedName: true,
+	}
+	if !qualified["pkg_a.Foo"] || !qualified["pkg_b.Foo"] {
+		t.Errorf("expected both qualified paths preserved, got %v", qualified)
+	}
+}
+
+// TestEdges_DedupCollapsesExactDuplicates confirms the fix didn't break the
+// existing guarantee: two identical edges (same src, dst, qualifiedDst, kind)
+// still collapse to one.
+func TestEdges_DedupCollapsesExactDuplicates(t *testing.T) {
+	t.Parallel()
+
+	ctx := &edgeContext{
+		seen: make(map[string]bool),
+	}
+	ctx.addEdgeQualified("main", "Foo", "pkg_a.Foo", "imports")
+	ctx.addEdgeQualified("main", "Foo", "pkg_a.Foo", "imports")
+
+	if len(ctx.edges) != 1 {
+		t.Fatalf("expected 1 edge for exact duplicate, got %d", len(ctx.edges))
+	}
+}

--- a/internal/parser/symbols.go
+++ b/internal/parser/symbols.go
@@ -268,15 +268,18 @@ func (p *Parser) extractGoTypeSymbols(node *tree_sitter.Node, source []byte, chu
 	}
 }
 
-// findContainingChunk returns the chunk index for the chunk whose line range contains the given line.
-// Returns 0 if no chunk contains the line.
+// findContainingChunk returns the chunk index for the chunk whose line range
+// contains the given line, or -1 if no chunk contains the line. Callers must
+// treat -1 as a sentinel (skip the symbol, log, etc.): a zero return was
+// previously ambiguous with "valid chunk at index 0", causing orphan
+// symbols to be silently mis-attributed to the first (often header) chunk.
 func findContainingChunk(line int, chunks []types.ChunkRecord) int64 {
 	for i := range chunks {
 		if line >= chunks[i].StartLine && line <= chunks[i].EndLine {
 			return int64(i)
 		}
 	}
-	return 0
+	return -1
 }
 
 // isGoExported returns true if the name starts with an uppercase letter (Go export rule).

--- a/internal/storage/migrations/postgres/007_pending_edges_file_id.sql
+++ b/internal/storage/migrations/postgres/007_pending_edges_file_id.sql
@@ -1,0 +1,26 @@
+-- +goose up
+
+-- Add file_id to pending_edges so resolved edges record their source file,
+-- allowing DeleteEdgesByFile to cascade correctly when a file is re-indexed.
+--
+-- Previously, ResolvePendingEdges INSERTed resolved rows into edges without
+-- file_id. DeleteEdgesByFile(fileID) filters by file_id, so resolved edges
+-- with NULL file_id never got cleaned up on file modification — the
+-- dependency graph silently accumulated stale edges.
+--
+-- No backfill: existing pending_edges rows lack the file_id we need, and
+-- reconstructing it from src_symbol_id → symbols.file_id would hide the
+-- fact that this table's schema is changing. The migration truncates all
+-- existing pending edges; a hard re-index is required after upgrade.
+
+TRUNCATE pending_edges;
+
+ALTER TABLE pending_edges
+    ADD COLUMN file_id BIGINT NOT NULL REFERENCES files(id) ON DELETE CASCADE;
+
+CREATE INDEX IF NOT EXISTS idx_pending_file ON pending_edges(file_id);
+
+-- +goose down
+
+DROP INDEX IF EXISTS idx_pending_file;
+ALTER TABLE pending_edges DROP COLUMN IF EXISTS file_id;

--- a/internal/storage/migrations/sqlite/003_pending_edges_file_id.sql
+++ b/internal/storage/migrations/sqlite/003_pending_edges_file_id.sql
@@ -1,0 +1,56 @@
+-- +goose up
+
+-- Add file_id to pending_edges so resolved edges record their source file,
+-- allowing DeleteEdgesByFile to cascade correctly when a file is re-indexed.
+--
+-- Previously, ResolvePendingEdges INSERTed resolved rows into edges without
+-- file_id. DeleteEdgesByFile(fileID) filters by file_id, so resolved edges
+-- with NULL file_id never got cleaned up on file modification — the
+-- dependency graph silently accumulated stale edges.
+--
+-- No backfill: existing pending_edges rows lack the file_id we need, and
+-- reconstructing it from src_symbol_id → symbols.file_id would hide the
+-- fact that this table's schema is changing. The migration drops all
+-- existing pending edges; a hard re-index is required after upgrade.
+--
+-- SQLite can't ADD COLUMN NOT NULL without DEFAULT, so we rewrite the
+-- table (the data is being discarded anyway).
+
+DROP TABLE IF EXISTS pending_edges;
+
+CREATE TABLE pending_edges (
+    id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+    src_symbol_id      INTEGER NOT NULL REFERENCES symbols(id) ON DELETE CASCADE,
+    file_id            INTEGER NOT NULL REFERENCES files(id) ON DELETE CASCADE,
+    dst_symbol_name    TEXT NOT NULL,
+    kind               TEXT NOT NULL
+        CHECK (kind IN ('imports', 'calls', 'type_ref', 'inherits', 'implements')),
+    created_at         TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    dst_qualified_name TEXT DEFAULT '',
+    src_language       TEXT DEFAULT ''
+);
+
+CREATE INDEX IF NOT EXISTS idx_pending_name ON pending_edges(dst_symbol_name);
+CREATE INDEX IF NOT EXISTS idx_pending_src ON pending_edges(src_symbol_id);
+CREATE INDEX IF NOT EXISTS idx_pending_file ON pending_edges(file_id);
+
+-- +goose down
+
+-- Downgrade: drop the table with the new shape and restore the original.
+-- Any rows are lost (symmetric to the up migration).
+
+DROP TABLE IF EXISTS pending_edges;
+
+CREATE TABLE pending_edges (
+    id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+    src_symbol_id      INTEGER NOT NULL REFERENCES symbols(id) ON DELETE CASCADE,
+    dst_symbol_name    TEXT NOT NULL,
+    kind               TEXT NOT NULL
+        CHECK (kind IN ('imports', 'calls', 'type_ref', 'inherits', 'implements')),
+    created_at         TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    dst_qualified_name TEXT DEFAULT '',
+    src_language       TEXT DEFAULT ''
+);
+
+CREATE INDEX IF NOT EXISTS idx_pending_name ON pending_edges(dst_symbol_name);
+CREATE INDEX IF NOT EXISTS idx_pending_src ON pending_edges(src_symbol_id);

--- a/internal/storage/postgres/graph.go
+++ b/internal/storage/postgres/graph.go
@@ -38,9 +38,9 @@ func (s *PgStore) InsertEdges(ctx context.Context, txh types.TxHandle, fileID in
 			}
 		} else {
 			_, err := tx.Exec(ctx,
-				`INSERT INTO pending_edges (src_symbol_id, dst_symbol_name, dst_qualified_name, kind, src_language)
-				 VALUES ($1, $2, $3, $4, $5)`,
-				srcID, e.DstSymbolName, e.DstQualifiedName, e.Kind, language)
+				`INSERT INTO pending_edges (src_symbol_id, file_id, dst_symbol_name, dst_qualified_name, kind, src_language)
+				 VALUES ($1, $2, $3, $4, $5, $6)`,
+				srcID, fileID, e.DstSymbolName, e.DstQualifiedName, e.Kind, language)
 			if err != nil {
 				return fmt.Errorf("insert pending edge %s→%s: %w", e.SrcSymbolName, e.DstSymbolName, err)
 			}
@@ -56,7 +56,7 @@ func (s *PgStore) ResolvePendingEdges(ctx context.Context, txh types.TxHandle, n
 	tx := txh.(PgTxHandle).Tx
 
 	rows, err := tx.Query(ctx, `
-		SELECT id, src_symbol_id, dst_symbol_name, kind, src_language
+		SELECT id, src_symbol_id, file_id, dst_symbol_name, kind, src_language
 		FROM pending_edges
 		WHERE dst_symbol_name = ANY($1)`, newSymbolNames)
 	if err != nil {
@@ -67,6 +67,7 @@ func (s *PgStore) ResolvePendingEdges(ctx context.Context, txh types.TxHandle, n
 	type pending struct {
 		id       int64
 		srcID    int64
+		fileID   int64
 		dstName  string
 		kind     string
 		language string
@@ -74,7 +75,7 @@ func (s *PgStore) ResolvePendingEdges(ctx context.Context, txh types.TxHandle, n
 	var toResolve []pending
 	for rows.Next() {
 		var p pending
-		if err := rows.Scan(&p.id, &p.srcID, &p.dstName, &p.kind, &p.language); err != nil {
+		if err := rows.Scan(&p.id, &p.srcID, &p.fileID, &p.dstName, &p.kind, &p.language); err != nil {
 			return err
 		}
 		toResolve = append(toResolve, p)
@@ -85,9 +86,11 @@ func (s *PgStore) ResolvePendingEdges(ctx context.Context, txh types.TxHandle, n
 		if dstID == 0 {
 			continue
 		}
+		// Preserve file_id on resolved edges so DeleteEdgesByFile can cascade.
 		if _, err := tx.Exec(ctx,
-			`INSERT INTO edges (src_symbol_id, dst_symbol_id, kind) VALUES ($1, $2, $3) ON CONFLICT DO NOTHING`,
-			p.srcID, dstID, p.kind); err != nil {
+			`INSERT INTO edges (src_symbol_id, dst_symbol_id, kind, file_id)
+			 VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING`,
+			p.srcID, dstID, p.kind, p.fileID); err != nil {
 			return fmt.Errorf("insert resolved edge %d→%d: %w", p.srcID, dstID, err)
 		}
 		if _, err := tx.Exec(ctx, "DELETE FROM pending_edges WHERE id = $1", p.id); err != nil {

--- a/internal/storage/postgres/metadata.go
+++ b/internal/storage/postgres/metadata.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"strings"
@@ -106,11 +107,23 @@ func (s *PgStore) DeleteFile(ctx context.Context, fileID int64) error {
 
 func (s *PgStore) DeleteFileByPath(ctx context.Context, path string) (int64, error) {
 	var fileID int64
-	err := s.pool.QueryRow(ctx, "SELECT id FROM files WHERE path = $1 AND project_id = $2", path, s.projectID).Scan(&fileID)
-	if err != nil {
-		return 0, nil // not found → no-op
-	}
-	_, err = s.pool.Exec(ctx, "DELETE FROM files WHERE id = $1", fileID)
+	err := s.WithWriteTx(ctx, func(txh types.TxHandle) error {
+		tx := txh.(PgTxHandle).Tx
+		lookupErr := tx.QueryRow(ctx,
+			"SELECT id FROM files WHERE path = $1 AND project_id = $2",
+			path, s.projectID).Scan(&fileID)
+		if errors.Is(lookupErr, pgx.ErrNoRows) {
+			fileID = 0
+			return nil // genuinely not found → no-op
+		}
+		if lookupErr != nil {
+			return fmt.Errorf("lookup file %s: %w", path, lookupErr)
+		}
+		if _, err := tx.Exec(ctx, "DELETE FROM files WHERE id = $1", fileID); err != nil {
+			return fmt.Errorf("delete file %d: %w", fileID, err)
+		}
+		return nil
+	})
 	return fileID, err
 }
 
@@ -138,12 +151,26 @@ func (s *PgStore) UpdateChunkParents(ctx context.Context, updates map[int64]int6
 	if len(updates) == 0 {
 		return nil
 	}
+	chunkIDs := make([]int64, 0, len(updates))
+	parentIDs := make([]int64, 0, len(updates))
 	for chunkID, parentID := range updates {
-		if _, err := s.pool.Exec(ctx, "UPDATE chunks SET parent_chunk_id = $1 WHERE id = $2", parentID, chunkID); err != nil {
-			return err
-		}
+		chunkIDs = append(chunkIDs, chunkID)
+		parentIDs = append(parentIDs, parentID)
 	}
-	return nil
+	return s.WithWriteTx(ctx, func(txh types.TxHandle) error {
+		tx := txh.(PgTxHandle).Tx
+		// Single batched UPDATE via UNNEST: one round-trip, one tx.
+		_, err := tx.Exec(ctx, `
+			UPDATE chunks AS c
+			SET parent_chunk_id = v.parent_id
+			FROM (SELECT unnest($1::bigint[]) AS chunk_id,
+			             unnest($2::bigint[]) AS parent_id) AS v
+			WHERE c.id = v.chunk_id`, chunkIDs, parentIDs)
+		if err != nil {
+			return fmt.Errorf("update chunk parents (%d rows): %w", len(updates), err)
+		}
+		return nil
+	})
 }
 
 // ── Chunk operations ──

--- a/internal/storage/sqlite/graph.go
+++ b/internal/storage/sqlite/graph.go
@@ -29,8 +29,8 @@ func (s *Store) InsertEdges(ctx context.Context, txh types.TxHandle, fileID int6
 	defer func() { _ = edgeStmt.Close() }()
 
 	pendingStmt, err := tx.PrepareContext(ctx, `
-		INSERT INTO pending_edges (src_symbol_id, dst_symbol_name, dst_qualified_name, kind, src_language)
-		VALUES (?, ?, ?, ?, ?)`)
+		INSERT INTO pending_edges (src_symbol_id, file_id, dst_symbol_name, dst_qualified_name, kind, src_language)
+		VALUES (?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		return fmt.Errorf("prepare pending edge insert: %w", err)
 	}
@@ -53,7 +53,7 @@ func (s *Store) InsertEdges(ctx context.Context, txh types.TxHandle, fileID int6
 				return fmt.Errorf("insert edge %s→%s: %w", e.SrcSymbolName, e.DstSymbolName, err)
 			}
 		} else {
-			if _, err := pendingStmt.ExecContext(ctx, srcID, e.DstSymbolName, e.DstQualifiedName, e.Kind, language); err != nil {
+			if _, err := pendingStmt.ExecContext(ctx, srcID, fileID, e.DstSymbolName, e.DstQualifiedName, e.Kind, language); err != nil {
 				return fmt.Errorf("insert pending edge %s→%s: %w", e.SrcSymbolName, e.DstSymbolName, err)
 			}
 		}
@@ -79,7 +79,7 @@ func (s *Store) ResolvePendingEdges(ctx context.Context, txh types.TxHandle, new
 	}
 
 	query := fmt.Sprintf(`
-		SELECT id, src_symbol_id, dst_symbol_name, kind, src_language
+		SELECT id, src_symbol_id, file_id, dst_symbol_name, kind, src_language
 		FROM pending_edges
 		WHERE dst_symbol_name IN (%s)`, strings.Join(placeholders, ","))
 
@@ -92,6 +92,7 @@ func (s *Store) ResolvePendingEdges(ctx context.Context, txh types.TxHandle, new
 	type pending struct {
 		id       int64
 		srcID    int64
+		fileID   int64
 		dstName  string
 		kind     string
 		language string
@@ -100,7 +101,7 @@ func (s *Store) ResolvePendingEdges(ctx context.Context, txh types.TxHandle, new
 
 	for rows.Next() {
 		var p pending
-		if err := rows.Scan(&p.id, &p.srcID, &p.dstName, &p.kind, &p.language); err != nil {
+		if err := rows.Scan(&p.id, &p.srcID, &p.fileID, &p.dstName, &p.kind, &p.language); err != nil {
 			return fmt.Errorf("scan pending edge: %w", err)
 		}
 		toResolve = append(toResolve, p)
@@ -113,9 +114,10 @@ func (s *Store) ResolvePendingEdges(ctx context.Context, txh types.TxHandle, new
 		return nil
 	}
 
+	// Preserve file_id on resolved edges so DeleteEdgesByFile can cascade.
 	edgeStmt, err := tx.PrepareContext(ctx, `
-		INSERT OR IGNORE INTO edges (src_symbol_id, dst_symbol_id, kind)
-		VALUES (?, ?, ?)`)
+		INSERT OR IGNORE INTO edges (src_symbol_id, dst_symbol_id, kind, file_id)
+		VALUES (?, ?, ?, ?)`)
 	if err != nil {
 		return fmt.Errorf("prepare edge resolve insert: %w", err)
 	}
@@ -133,7 +135,7 @@ func (s *Store) ResolvePendingEdges(ctx context.Context, txh types.TxHandle, new
 			continue
 		}
 
-		if _, err := edgeStmt.ExecContext(ctx, p.srcID, dstID, p.kind); err != nil {
+		if _, err := edgeStmt.ExecContext(ctx, p.srcID, dstID, p.kind, p.fileID); err != nil {
 			return fmt.Errorf("resolve edge %d: %w", p.id, err)
 		}
 		if _, err := delStmt.ExecContext(ctx, p.id); err != nil {

--- a/internal/storage/sqlite/graph_test.go
+++ b/internal/storage/sqlite/graph_test.go
@@ -820,7 +820,7 @@ func TestPendingEdges_QualifiedNameAndLanguageColumns(t *testing.T) {
 	// Verify dst_qualified_name and src_language columns exist
 	err = db.WithWriteTx(func(tx *sql.Tx) error {
 		_, execErr := tx.ExecContext(ctx,
-			"INSERT INTO pending_edges (src_symbol_id, dst_symbol_name, dst_qualified_name, kind, src_language) VALUES (1, 'Foo', 'com.example.Foo', 'imports', 'java')")
+			"INSERT INTO pending_edges (src_symbol_id, file_id, dst_symbol_name, dst_qualified_name, kind, src_language) VALUES (1, 1, 'Foo', 'com.example.Foo', 'imports', 'java')")
 		return execErr
 	})
 	if err != nil {

--- a/internal/storage/sqlite/metadata.go
+++ b/internal/storage/sqlite/metadata.go
@@ -3,6 +3,7 @@ package sqlite
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -142,15 +143,22 @@ func (s *Store) DeleteFile(ctx context.Context, fileID int64) error {
 
 // DeleteFileByPath removes a file by path and cascades to chunks/symbols.
 // Returns the file ID that was deleted, or 0 if not found.
+// Returns a non-nil error only for genuine failures (e.g. DB locked,
+// corruption) — a missing row is not an error.
 func (s *Store) DeleteFileByPath(ctx context.Context, path string) (int64, error) {
 	var fileID int64
 	err := s.db.WithWriteTx(func(tx *sql.Tx) error {
 		err := tx.QueryRowContext(ctx, "SELECT id FROM files WHERE path = ?", path).Scan(&fileID)
-		if err != nil {
-			return nil // not found → no-op
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil // genuinely not found → no-op
 		}
-		_, err = tx.ExecContext(ctx, "DELETE FROM files WHERE id = ?", fileID)
-		return err
+		if err != nil {
+			return fmt.Errorf("lookup file %s: %w", path, err)
+		}
+		if _, err := tx.ExecContext(ctx, "DELETE FROM files WHERE id = ?", fileID); err != nil {
+			return fmt.Errorf("delete file %d: %w", fileID, err)
+		}
+		return nil
 	})
 	return fileID, err
 }

--- a/internal/storage/storetest/suite.go
+++ b/internal/storage/storetest/suite.go
@@ -488,6 +488,22 @@ func RunWriterStoreTests(t *testing.T, factory WriterStoreFactory) {
 		}
 	})
 
+	t.Run("DeleteFileByPath_PropagatesGenuineErrors", func(t *testing.T) {
+		// A cancelled context is a transient error — distinct from ErrNoRows.
+		// The previous implementation swallowed all lookup errors as "not
+		// found" which silently hid DB-level failures (locked, corrupt).
+		// The fix uses errors.Is(err, sql.ErrNoRows)/pgx.ErrNoRows to
+		// distinguish; cancelled context must propagate.
+		store := factory(t)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // pre-cancel before the call
+
+		_, err := store.DeleteFileByPath(ctx, "anything.go")
+		if err == nil {
+			t.Error("expected cancelled context to surface as an error, got nil")
+		}
+	})
+
 	t.Run("GetEmbeddedChunkIDsByFile", func(t *testing.T) {
 		store := factory(t)
 		ctx := context.Background()

--- a/internal/storage/storetest/suite.go
+++ b/internal/storage/storetest/suite.go
@@ -854,4 +854,48 @@ func RunGraphMutatorTests(t *testing.T, factory WriterStoreFactory) {
 			t.Error("expected resolved edge to appear in Neighbors")
 		}
 	})
+
+	t.Run("ResolvePendingEdges_EdgeCleanedOnFileDelete", func(t *testing.T) {
+		// Regression test: resolved edges must carry the originating file_id
+		// so DeleteEdgesByFile can cascade them on re-index.
+		//
+		// Before the fix, ResolvePendingEdges inserted edges without file_id.
+		// DeleteEdgesByFile filters by file_id, so resolved edges survived
+		// file deletion indefinitely — the graph silently accumulated stale
+		// edges as files were re-indexed.
+		store := factory(t)
+		ctx := context.Background()
+
+		// Caller lives in file A; Target is not yet defined → pending edge.
+		fileA, _, symA := insertFCS(t, store, "a.go", "Caller")
+		edges := []types.EdgeRecord{
+			{SrcSymbolName: "Caller", DstSymbolName: "Target", Kind: "calls"},
+		}
+		if err := store.WithWriteTx(ctx, func(tx types.TxHandle) error {
+			return store.InsertEdges(ctx, tx, fileA, edges, map[string]int64{"Caller": symA}, "go")
+		}); err != nil {
+			t.Fatalf("InsertEdges: %v", err)
+		}
+
+		// Now define Target — resolves the pending edge.
+		insertFCS(t, store, "b.go", "Target")
+		if err := store.WithWriteTx(ctx, func(tx types.TxHandle) error {
+			return store.ResolvePendingEdges(ctx, tx, []string{"Target"})
+		}); err != nil {
+			t.Fatalf("ResolvePendingEdges: %v", err)
+		}
+
+		// The resolved edge originated in file A. Delete edges for file A.
+		if err := store.WithWriteTx(ctx, func(tx types.TxHandle) error {
+			return store.DeleteEdgesByFile(ctx, tx, fileA)
+		}); err != nil {
+			t.Fatalf("DeleteEdgesByFile: %v", err)
+		}
+
+		// Caller should now have no outgoing neighbors; the stale edge is gone.
+		neighbors, _ := store.Neighbors(ctx, symA, 1, "outgoing")
+		if len(neighbors) != 0 {
+			t.Errorf("expected resolved edge to be cleaned by DeleteEdgesByFile, got %d neighbors", len(neighbors))
+		}
+	})
 }

--- a/internal/vector/bruteforce/store.go
+++ b/internal/vector/bruteforce/store.go
@@ -78,9 +78,21 @@ func (s *Store) Search(_ context.Context, query []float32, topK int) ([]types.Ve
 	if k > n {
 		k = n
 	}
+	// Skipped counts surface silent corruption that would otherwise poison
+	// the heap comparator (NaN comparisons are always false) or panic on a
+	// length mismatch inside the hot loop in cosineSimilarity.
+	var skippedDim, skippedNaN int
 	h := make(scoreHeap, 0, k)
 	for id, vec := range s.vectors {
+		if len(vec) != s.dim {
+			skippedDim++
+			continue
+		}
 		sim := cosineSimilarity(query, vec)
+		if math.IsNaN(sim) || math.IsInf(sim, 0) {
+			skippedNaN++
+			continue
+		}
 		if h.Len() < topK {
 			heap.Push(&h, scored{id, sim})
 		} else if sim > h[0].score {
@@ -89,6 +101,12 @@ func (s *Store) Search(_ context.Context, query []float32, topK int) ([]types.Ve
 		}
 	}
 	s.mu.RUnlock()
+
+	if skippedDim > 0 || skippedNaN > 0 {
+		slog.Warn("bruteforce search skipped invalid vectors",
+			"dim_mismatch", skippedDim, "nan_or_inf", skippedNaN,
+			"total_indexed", n, "store_dim", s.dim)
+	}
 
 	// Extract results in descending order (highest score first).
 	out := make([]types.VectorResult, h.Len())
@@ -313,12 +331,11 @@ func (s *Store) LoadFromDisk(path string) error {
 		return fmt.Errorf("embedding file dim %d != expected %d (model changed?)", dim, s.dim)
 	}
 
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.dim = int(dim)
-	s.vectors = make(map[int64][]float32, count)
-
-	// Read entries (direct byte decoding — avoids binary.Read reflection per vector)
+	// Decode entries into a fresh local map, swap into the store only on
+	// success. Previously any error past this point (notably the CRC
+	// mismatch below) left s.vectors partially populated, wiping whatever
+	// was there before and returning an error — the worst possible outcome.
+	loaded := make(map[int64][]float32, count)
 	entryBuf := make([]byte, 8+int(dim)*4)
 	for i := uint32(0); i < count; i++ {
 		if _, err := io.ReadFull(r, entryBuf); err != nil {
@@ -329,7 +346,7 @@ func (s *Store) LoadFromDisk(path string) error {
 		for j := range vec {
 			vec[j] = math.Float32frombits(binary.LittleEndian.Uint32(entryBuf[8+j*4:]))
 		}
-		s.vectors[id] = vec
+		loaded[id] = vec
 	}
 
 	// v2: verify CRC32 integrity
@@ -345,8 +362,14 @@ func (s *Store) LoadFromDisk(path string) error {
 		}
 	}
 
+	// Atomic swap: existing s.vectors preserved on any error above.
+	s.mu.Lock()
+	s.dim = int(dim)
+	s.vectors = loaded
+	s.mu.Unlock()
+
 	slog.Info("embeddings loaded from disk",
-		"path", path, "count", len(s.vectors),
+		"path", path, "count", len(loaded),
 		"duration_ms", time.Since(start).Milliseconds())
 	return nil
 }

--- a/internal/vector/bruteforce/store_test.go
+++ b/internal/vector/bruteforce/store_test.go
@@ -741,3 +741,87 @@ func TestStore_SaveToDisk_ConcurrentUpsert(t *testing.T) {
 		t.Errorf("expected >= 500 vectors, got %d", count)
 	}
 }
+
+// TestStore_LoadFromDisk_PreservesStateOnCRCFailure verifies the atomic
+// swap: a corrupted file triggers a CRC mismatch, and the existing store
+// state must survive intact rather than being partially overwritten.
+func TestStore_LoadFromDisk_PreservesStateOnCRCFailure(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "embeddings.bin")
+
+	// Produce a well-formed snapshot.
+	s := NewStore(3)
+	s.Upsert(ctx, 1, []float32{1, 0, 0})
+	s.Upsert(ctx, 2, []float32{0, 1, 0})
+	if err := s.SaveToDisk(path); err != nil {
+		t.Fatalf("SaveToDisk: %v", err)
+	}
+
+	// Corrupt the CRC footer by flipping the last byte.
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	raw[len(raw)-1] ^= 0xff
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatalf("write corrupted: %v", err)
+	}
+
+	// Seed s2 with pre-existing state that must survive the failed load.
+	s2 := NewStore(3)
+	s2.Upsert(ctx, 42, []float32{0, 0, 1})
+
+	loadErr := s2.LoadFromDisk(path)
+	if loadErr == nil {
+		t.Fatalf("expected CRC mismatch error, got nil")
+	}
+
+	// Old state must survive: chunk 42 still present, corrupted file's
+	// chunks 1,2 must NOT leak into s2.vectors.
+	count, _ := s2.Count(ctx)
+	if count != 1 {
+		t.Errorf("expected 1 preserved entry after failed load, got %d", count)
+	}
+	has, _ := s2.Has(ctx, 42)
+	if !has {
+		t.Errorf("pre-load entry 42 lost after failed load")
+	}
+	has1, _ := s2.Has(ctx, 1)
+	if has1 {
+		t.Errorf("partial load leaked entry 1 into store after CRC failure")
+	}
+}
+
+// TestStore_Search_SkipsNaNAndDimMismatch verifies the hot path defends
+// against poisoned vectors. A NaN in a stored vector previously returned
+// NaN from cosineSimilarity, which poisoned the heap comparator and
+// silently produced wrong top-K ordering.
+func TestStore_Search_SkipsNaNAndDimMismatch(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	s := NewStore(3)
+
+	// Valid vector — should win.
+	s.Upsert(ctx, 1, []float32{1, 0, 0})
+
+	// Bypass Upsert's dim guard by writing directly — simulates a
+	// corrupted LoadFromDisk or a backend bug that put a wrong-dim vector
+	// in the map.
+	s.mu.Lock()
+	s.vectors[2] = []float32{1, 0} // wrong dim
+	s.vectors[3] = []float32{float32(math.NaN()), 0, 0}
+	s.mu.Unlock()
+
+	results, err := s.Search(ctx, []float32{1, 0, 0}, 10)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 valid result, got %d: %+v", len(results), results)
+	}
+	if results[0].ChunkID != 1 {
+		t.Errorf("expected ChunkID=1, got %d", results[0].ChunkID)
+	}
+}

--- a/internal/vector/embed_validate.go
+++ b/internal/vector/embed_validate.go
@@ -1,0 +1,114 @@
+package vector
+
+import (
+	"log/slog"
+	"math"
+)
+
+// sanitizeEmbeddings filters out vectors that would corrupt downstream
+// similarity search: all-zero vectors (produced by some embedders on
+// whitespace-only or degenerate inputs), NaN/Inf components (model or
+// transport errors surfaced silently), and dimension mismatches (which
+// would panic bruteforce.Search on a shorter stored vector or produce
+// nonsense for a longer one).
+//
+// Returns the filtered chunk-id and vector slices, and a counter of
+// rejected vectors by reason. The returned slices are fresh allocations
+// and preserve the order of accepted entries.
+//
+// expectDim == 0 disables the dim check (useful when the caller doesn't
+// know the store's dim yet, e.g. first-time upsert).
+func sanitizeEmbeddings(chunkIDs []int64, vectors [][]float32, expectDim int, log *slog.Logger) ([]int64, [][]float32, embedReject) {
+	var r embedReject
+	outIDs := make([]int64, 0, len(chunkIDs))
+	outVecs := make([][]float32, 0, len(vectors))
+
+	n := len(vectors)
+	if len(chunkIDs) < n {
+		n = len(chunkIDs)
+	}
+
+	for i := 0; i < n; i++ {
+		v := vectors[i]
+		id := chunkIDs[i]
+
+		if len(v) == 0 {
+			r.empty++
+			continue
+		}
+		if expectDim > 0 && len(v) != expectDim {
+			r.dimMismatch++
+			if log != nil {
+				log.Warn("embedding rejected: dim mismatch",
+					"chunk_id", id, "got", len(v), "want", expectDim)
+			}
+			continue
+		}
+
+		reason := scanVectorHealth(v)
+		switch reason {
+		case vecOK:
+			outIDs = append(outIDs, id)
+			outVecs = append(outVecs, v)
+		case vecZero:
+			r.zero++
+		case vecNaN:
+			r.naN++
+			if log != nil {
+				log.Warn("embedding rejected: NaN component", "chunk_id", id)
+			}
+		case vecInf:
+			r.inf++
+			if log != nil {
+				log.Warn("embedding rejected: Inf component", "chunk_id", id)
+			}
+		}
+	}
+
+	return outIDs, outVecs, r
+}
+
+type embedReject struct {
+	zero        int
+	naN         int
+	inf         int
+	empty       int
+	dimMismatch int
+}
+
+func (r embedReject) total() int {
+	return r.zero + r.naN + r.inf + r.empty + r.dimMismatch
+}
+
+type vecHealth int
+
+const (
+	vecOK vecHealth = iota
+	vecZero
+	vecNaN
+	vecInf
+)
+
+// scanVectorHealth returns the first health-reason encountered on v.
+// An all-zero vector is reported as vecZero even if it contains no
+// NaN/Inf, because it would cause downstream cosine similarity to
+// degenerate to 0 across every comparison.
+func scanVectorHealth(v []float32) vecHealth {
+	allZero := true
+	for _, f := range v {
+		f64 := float64(f)
+		if math.IsNaN(f64) {
+			return vecNaN
+		}
+		if math.IsInf(f64, 0) {
+			return vecInf
+		}
+		if f != 0 {
+			allZero = false
+		}
+	}
+	if allZero {
+		return vecZero
+	}
+	return vecOK
+}

--- a/internal/vector/embed_validate_test.go
+++ b/internal/vector/embed_validate_test.go
@@ -1,0 +1,127 @@
+package vector
+
+import (
+	"math"
+	"testing"
+)
+
+func TestSanitizeEmbeddings_Valid(t *testing.T) {
+	t.Parallel()
+
+	ids := []int64{1, 2, 3}
+	vecs := [][]float32{
+		{0.1, 0.2, 0.3},
+		{-0.5, 0.5, 0.7},
+		{0.9, 0.1, 0.05},
+	}
+	outIDs, outVecs, rej := sanitizeEmbeddings(ids, vecs, 3, nil)
+
+	if len(outIDs) != 3 || len(outVecs) != 3 {
+		t.Fatalf("expected 3 accepted; got %d/%d", len(outIDs), len(outVecs))
+	}
+	if rej.total() != 0 {
+		t.Errorf("expected 0 rejections, got %+v", rej)
+	}
+}
+
+func TestSanitizeEmbeddings_DropsZeroVector(t *testing.T) {
+	t.Parallel()
+
+	ids := []int64{1, 2}
+	vecs := [][]float32{
+		{0.1, 0.2, 0.3},
+		{0, 0, 0},
+	}
+	outIDs, _, rej := sanitizeEmbeddings(ids, vecs, 3, nil)
+	if len(outIDs) != 1 || outIDs[0] != 1 {
+		t.Errorf("expected [1]; got %v", outIDs)
+	}
+	if rej.zero != 1 {
+		t.Errorf("expected zero=1, got %+v", rej)
+	}
+}
+
+func TestSanitizeEmbeddings_DropsNaN(t *testing.T) {
+	t.Parallel()
+
+	nan := float32(math.NaN())
+	ids := []int64{1, 2}
+	vecs := [][]float32{
+		{0.1, nan, 0.3},
+		{0.5, 0.5, 0.5},
+	}
+	outIDs, _, rej := sanitizeEmbeddings(ids, vecs, 3, nil)
+	if len(outIDs) != 1 || outIDs[0] != 2 {
+		t.Errorf("expected [2]; got %v", outIDs)
+	}
+	if rej.naN != 1 {
+		t.Errorf("expected naN=1, got %+v", rej)
+	}
+}
+
+func TestSanitizeEmbeddings_DropsInf(t *testing.T) {
+	t.Parallel()
+
+	inf := float32(math.Inf(1))
+	ids := []int64{1}
+	vecs := [][]float32{{0.1, inf, 0.3}}
+	outIDs, _, rej := sanitizeEmbeddings(ids, vecs, 3, nil)
+	if len(outIDs) != 0 {
+		t.Errorf("expected 0 accepted; got %v", outIDs)
+	}
+	if rej.inf != 1 {
+		t.Errorf("expected inf=1, got %+v", rej)
+	}
+}
+
+func TestSanitizeEmbeddings_DropsDimMismatch(t *testing.T) {
+	t.Parallel()
+
+	ids := []int64{1, 2}
+	vecs := [][]float32{
+		{0.1, 0.2}, // dim=2, expect=3
+		{0.1, 0.2, 0.3},
+	}
+	outIDs, _, rej := sanitizeEmbeddings(ids, vecs, 3, nil)
+	if len(outIDs) != 1 || outIDs[0] != 2 {
+		t.Errorf("expected [2]; got %v", outIDs)
+	}
+	if rej.dimMismatch != 1 {
+		t.Errorf("expected dimMismatch=1, got %+v", rej)
+	}
+}
+
+func TestSanitizeEmbeddings_DropsEmpty(t *testing.T) {
+	t.Parallel()
+
+	ids := []int64{1, 2}
+	vecs := [][]float32{
+		nil,
+		{0.1, 0.2, 0.3},
+	}
+	outIDs, _, rej := sanitizeEmbeddings(ids, vecs, 3, nil)
+	if len(outIDs) != 1 || outIDs[0] != 2 {
+		t.Errorf("expected [2]; got %v", outIDs)
+	}
+	if rej.empty != 1 {
+		t.Errorf("expected empty=1, got %+v", rej)
+	}
+}
+
+func TestSanitizeEmbeddings_DisableDimCheck(t *testing.T) {
+	t.Parallel()
+
+	ids := []int64{1, 2}
+	vecs := [][]float32{
+		{0.1, 0.2}, // dim=2
+		{0.1, 0.2, 0.3}, // dim=3
+	}
+	// expectDim=0 disables dim check, so both survive.
+	outIDs, _, rej := sanitizeEmbeddings(ids, vecs, 0, nil)
+	if len(outIDs) != 2 {
+		t.Errorf("expected both; got %v", outIDs)
+	}
+	if rej.dimMismatch != 0 {
+		t.Errorf("expected dimMismatch=0, got %+v", rej)
+	}
+}

--- a/internal/vector/embed_worker.go
+++ b/internal/vector/embed_worker.go
@@ -178,17 +178,37 @@ func (w *EmbedWorker) processBatch(ctx context.Context, batch []EmbedJob) {
 		chunkIDs[i] = j.ChunkID
 	}
 
-	if err := w.store.UpsertBatch(ctx, chunkIDs, vectors); err != nil {
+	// Drop vectors that would corrupt downstream search (zero/NaN/Inf/wrong dim).
+	// Dim is 0 here because processBatch doesn't have direct access to the
+	// store's configured dim; the store's own Upsert path validates dim.
+	cleanIDs, cleanVecs, rej := sanitizeEmbeddings(chunkIDs, vectors, 0, w.logger)
+	if rej.total() > 0 {
+		w.logger.Warn("embeddings rejected before upsert",
+			"batch_size", len(batch),
+			"zero", rej.zero, "nan", rej.naN, "inf", rej.inf,
+			"empty", rej.empty, "dim_mismatch", rej.dimMismatch)
+	}
+	if len(cleanIDs) == 0 {
+		w.logger.Warn("embed batch dropped: all vectors invalid", "size", len(batch))
+		return
+	}
+
+	if err := w.store.UpsertBatch(ctx, cleanIDs, cleanVecs); err != nil {
 		w.logger.Error("upsert batch failed", "err", err)
 		return
 	}
 
 	w.logger.Info("embed batch completed",
 		"size", len(batch),
+		"accepted", len(cleanIDs),
+		"rejected", rej.total(),
 		"duration_ms", time.Since(start).Milliseconds())
 
 	if w.onBatchDone != nil {
-		w.onBatchDone(chunkIDs)
+		// onBatchDone semantically means "these chunks are embedded". Pass
+		// only the accepted IDs so the DB doesn't mark rejected chunks
+		// as embedded.
+		w.onBatchDone(cleanIDs)
 	}
 }
 
@@ -373,9 +393,18 @@ func (w *EmbedWorker) reconcileAndEmbed(ctx context.Context, source types.EmbedS
 		return nil
 	}
 
-	// Success — upsert and mark.
-	if err := w.store.UpsertBatch(ctx, needIDs, vectors); err != nil {
-		return fmt.Errorf("upsert batch: %w", err)
+	// Success — sanitize then upsert and mark.
+	cleanIDs, cleanVecs, rej := sanitizeEmbeddings(needIDs, vectors, 0, w.logger)
+	if rej.total() > 0 {
+		w.logger.Warn("embeddings rejected before upsert",
+			"batch_size", len(needIDs),
+			"zero", rej.zero, "nan", rej.naN, "inf", rej.inf,
+			"empty", rej.empty, "dim_mismatch", rej.dimMismatch)
+	}
+	if len(cleanIDs) > 0 {
+		if err := w.store.UpsertBatch(ctx, cleanIDs, cleanVecs); err != nil {
+			return fmt.Errorf("upsert batch: %w", err)
+		}
 	}
 	if err := source.MarkChunksEmbedded(ctx, batchIDs); err != nil {
 		return fmt.Errorf("mark chunks embedded: %w", err)
@@ -490,7 +519,17 @@ func (w *EmbedWorker) retryDeferred(ctx context.Context, rs *runState) error {
 			}
 			w.cb.RecordSuccess()
 
-			if err := w.store.Upsert(ctx, dc.job.ChunkID, vecs[0]); err != nil {
+			// Sanitize single-vector upsert too; reuse the batch helper.
+			cleanIDs, cleanVecs, rej := sanitizeEmbeddings(
+				[]int64{dc.job.ChunkID}, [][]float32{vecs[0]}, 0, w.logger)
+			if len(cleanIDs) == 0 {
+				rs.skipped++
+				w.logger.Warn("deferred chunk rejected by sanitizer",
+					"chunk_id", dc.job.ChunkID,
+					"zero", rej.zero, "nan", rej.naN, "inf", rej.inf)
+				continue
+			}
+			if err := w.store.Upsert(ctx, cleanIDs[0], cleanVecs[0]); err != nil {
 				return fmt.Errorf("upsert deferred chunk %d: %w", dc.job.ChunkID, err)
 			}
 		}


### PR DESCRIPTION
-  propagate genuine errors in DeleteFileByPath; batch Pg parent updates
- preserve file_id on resolved edges so DeleteEdgesByFile cascades
- reject poisoned embeddings; atomic bruteforce load; dim/NaN guard in search
-  depth guard for structural recursion; recover panics; edge dedup; orphan-symbol sentinel