### PR TITLE
Batch 3 daemon resilience

### DIFF
--- a/cmd/shaktimand/main.go
+++ b/cmd/shaktimand/main.go
@@ -7,11 +7,11 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math/rand/v2"
 	"os"
 	"os/signal"
 	"path/filepath"
 	"syscall"
-
 	"time"
 
 	"github.com/shaktimanai/shaktiman/internal/daemon"
@@ -19,6 +19,28 @@ import (
 	"github.com/shaktimanai/shaktiman/internal/proxy"
 	"github.com/shaktimanai/shaktiman/internal/types"
 )
+
+// promotionWaitTimeout bounds how long a freshly-promoted proxy waits
+// for the leader socket to come up. Cold indexes on large repositories
+// routinely exceed the original 5s bound; 30s covers typical cold
+// starts while still failing loudly on genuinely broken leaders.
+const promotionWaitTimeout = 30 * time.Second
+
+// promotionBackoffMin and Max bound the jittered sleep before a proxy
+// re-execs itself to claim the leader slot. On a simultaneous
+// leader-exit event, multiple proxies would otherwise all re-exec in
+// lockstep; the loser(s) then race WaitForSocket against a cold leader
+// start-up. Jitter spreads the attempts out.
+const (
+	promotionBackoffMin = 50 * time.Millisecond
+	promotionBackoffMax = 500 * time.Millisecond
+)
+
+// promotionBackoff returns a uniformly-random sleep within the
+// [promotionBackoffMin, promotionBackoffMax] window.
+func promotionBackoff() time.Duration {
+	return promotionBackoffMin + rand.N(promotionBackoffMax-promotionBackoffMin)
+}
 
 func main() {
 	if len(os.Args) < 2 {
@@ -177,7 +199,7 @@ func runAsProxy(projectRoot string) {
 
 	slog.Info("entering proxy mode", "project_root", projectRoot, "socket", sockPath)
 
-	if err := proxy.WaitForSocket(sockPath, 5*time.Second); err != nil {
+	if err := proxy.WaitForSocket(sockPath, promotionWaitTimeout); err != nil {
 		fmt.Fprintf(os.Stderr, "error: leader daemon socket not available: %v\n", err)
 		fmt.Fprintf(os.Stderr, "hint: the leader daemon may still be starting up\n")
 		os.Exit(1)
@@ -196,11 +218,30 @@ func runAsProxy(projectRoot string) {
 	bridgeErr := b.Run(ctx)
 
 	if errors.Is(bridgeErr, proxy.ErrLeaderGone) {
-		slog.Info("leader exited, attempting promotion via re-exec")
+		// Jittered backoff spreads simultaneous promotion attempts across
+		// concurrent proxies; without it, all proxies that observe
+		// ErrLeaderGone re-exec in lockstep and the losers race
+		// WaitForSocket against a cold-starting leader.
+		sleep := promotionBackoff()
+		slog.Info("leader exited, promoting via re-exec after backoff",
+			"backoff_ms", sleep.Milliseconds())
+		time.Sleep(sleep)
+
+		// Resolve our canonical executable path. os.Args[0] may be a
+		// relative path or a name resolved via $PATH, which Exec will
+		// re-resolve from the NEW process's cwd/env — brittle across
+		// binary upgrades or working-directory changes between start
+		// and promotion.
+		exe, exeErr := os.Executable()
+		if exeErr != nil {
+			fmt.Fprintf(os.Stderr, "error: resolve own executable for re-exec: %v\n", exeErr)
+			os.Exit(1)
+		}
+
 		// Re-exec: flock fd has O_CLOEXEC (Go default), stdin/stdout preserved.
 		// The re-exec'd process will attempt flock and succeed (old leader released it).
 		// If another proxy wins the race, we re-enter proxy mode.
-		execErr := syscall.Exec(os.Args[0], os.Args, os.Environ()) //nolint:gosec // re-exec of own binary for leader promotion; os.Args[0] is this process's own path
+		execErr := syscall.Exec(exe, os.Args, os.Environ()) //nolint:gosec // re-exec of own binary for leader promotion; exe resolved via os.Executable()
 
 		// Exec replaces the process; if we get here, it failed.
 		fmt.Fprintf(os.Stderr, "error: re-exec failed: %v\n", execErr)

--- a/cmd/shaktimand/main.go
+++ b/cmd/shaktimand/main.go
@@ -197,10 +197,14 @@ func runAsProxy(projectRoot string) {
 		os.Exit(1)
 	}
 
-	slog.Info("entering proxy mode", "project_root", projectRoot, "socket", sockPath)
+	markerPath := daemon.ReadyMarkerPath(projectRoot)
+	slog.Info("entering proxy mode",
+		"project_root", projectRoot,
+		"socket", sockPath,
+		"marker", markerPath)
 
-	if err := proxy.WaitForSocket(sockPath, promotionWaitTimeout); err != nil {
-		fmt.Fprintf(os.Stderr, "error: leader daemon socket not available: %v\n", err)
+	if err := proxy.WaitForReady(sockPath, markerPath, promotionWaitTimeout); err != nil {
+		fmt.Fprintf(os.Stderr, "error: leader daemon not ready: %v\n", err)
 		fmt.Fprintf(os.Stderr, "hint: the leader daemon may still be starting up\n")
 		os.Exit(1)
 	}

--- a/cmd/shaktimand/main_test.go
+++ b/cmd/shaktimand/main_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+// TestPromotionBackoff_InRange verifies the jitter helper produces
+// durations within the declared bounds. Without jitter, concurrent
+// proxies all re-exec simultaneously on leader exit and race the cold
+// leader's socket startup.
+func TestPromotionBackoff_InRange(t *testing.T) {
+	t.Parallel()
+
+	for range 1000 {
+		got := promotionBackoff()
+		if got < promotionBackoffMin {
+			t.Errorf("backoff %v < min %v", got, promotionBackoffMin)
+		}
+		if got > promotionBackoffMax {
+			t.Errorf("backoff %v > max %v", got, promotionBackoffMax)
+		}
+	}
+}
+
+// TestPromotionBackoff_Distribution sanity-checks that the helper does
+// not collapse to a single value (which would indicate a constant
+// rather than a jittered choice).
+func TestPromotionBackoff_Distribution(t *testing.T) {
+	t.Parallel()
+
+	seen := make(map[time.Duration]int)
+	for range 500 {
+		seen[promotionBackoff()]++
+	}
+	if len(seen) < 50 {
+		t.Errorf("expected >50 distinct backoff values, got %d", len(seen))
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -6,6 +6,8 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"os"
+	"path/filepath"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -20,6 +22,23 @@ import (
 
 	mcpserver "github.com/mark3labs/mcp-go/server"
 )
+
+// ReadyMarkerName is the file written under .shaktiman/ when the leader's
+// MCP socket server is accepting connections. Proxies wait for this
+// before dialing to avoid races against partially-initialized leaders.
+const ReadyMarkerName = "ready"
+
+// socketShutdownTimeout bounds graceful socket-server shutdown. The
+// previous 2s budget aborted in-flight tools/call mid-stream, surfacing
+// to clients as truncated JSON responses; 15s gives realistic tool
+// invocations time to drain.
+const socketShutdownTimeout = 15 * time.Second
+
+// ReadyMarkerPath returns the absolute path of the readiness marker
+// file for a given project root.
+func ReadyMarkerPath(projectRoot string) string {
+	return filepath.Join(projectRoot, ".shaktiman", ReadyMarkerName)
+}
 
 // parserVersionConfigKey is the config-table key under which the parser
 // chunk algorithm version is persisted. When the running code's
@@ -227,6 +246,15 @@ func (d *Daemon) Start(ctx context.Context) error {
 		mux := http.NewServeMux()
 		mux.Handle("/mcp", httpHandler)
 		d.socketServer = &http.Server{Handler: mux, ReadHeaderTimeout: 10 * time.Second}
+
+		readyPath := ReadyMarkerPath(d.cfg.ProjectRoot)
+		// Write the readiness marker just before Serve. The window between
+		// marker creation and the accept loop being live is sub-millisecond;
+		// the kernel listen backlog absorbs any dial that races.
+		if err := writeReadyMarker(readyPath, d.sessionID); err != nil {
+			d.logger.Warn("write ready marker failed", "err", err, "path", readyPath)
+		}
+
 		go func() {
 			d.logger.Info("MCP socket server starting", "addr", d.SocketListener.Addr().String())
 			if err := d.socketServer.Serve(d.SocketListener); err != nil && err != http.ErrServerClosed {
@@ -432,9 +460,15 @@ func (d *Daemon) Stop() error {
 	start := time.Now()
 	d.logger.Info("shutting down")
 
+	// Remove the readiness marker so proxies that race their dial against
+	// our shutdown observe the down state via marker absence.
+	_ = os.Remove(ReadyMarkerPath(d.cfg.ProjectRoot))
+
 	// Shut down socket server first so proxies see connection-refused quickly.
+	// The deadline must be long enough for in-flight tools/call requests to
+	// drain — a 2s budget surfaced as truncated JSON to clients.
 	if d.socketServer != nil {
-		socketCtx, socketCancel := context.WithTimeout(context.Background(), 2*time.Second)
+		socketCtx, socketCancel := context.WithTimeout(context.Background(), socketShutdownTimeout)
 		if err := d.socketServer.Shutdown(socketCtx); err != nil {
 			d.logger.Warn("socket server shutdown error", "err", err)
 		}
@@ -477,6 +511,36 @@ func (d *Daemon) Stop() error {
 	return nil
 }
 
+
+// writeReadyMarker creates the readiness marker file. The marker holds the
+// leader's session ID so that future tooling can correlate proxy mode
+// with the leader instance it is bridging to. Writes are atomic via
+// rename so a partially-written file is never observed.
+func writeReadyMarker(path, sessionID string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return fmt.Errorf("mkdir ready marker dir: %w", err)
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".ready-*")
+	if err != nil {
+		return fmt.Errorf("create temp ready marker: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+
+	payload := fmt.Sprintf("session_id=%s\npid=%d\nstarted=%s\n",
+		sessionID, os.Getpid(), time.Now().UTC().Format(time.RFC3339))
+	if _, err := tmp.WriteString(payload); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write ready marker: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close ready marker: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("rename ready marker into place: %w", err)
+	}
+	return nil
+}
 
 // saveVectors persists vectors if the store supports explicit persistence.
 func (d *Daemon) saveVectors(path string) error {

--- a/internal/daemon/ready_test.go
+++ b/internal/daemon/ready_test.go
@@ -1,0 +1,77 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestReadyMarkerPath(t *testing.T) {
+	t.Parallel()
+
+	got := ReadyMarkerPath("/tmp/proj")
+	want := filepath.Join("/tmp/proj", ".shaktiman", "ready")
+	if got != want {
+		t.Fatalf("ReadyMarkerPath = %q, want %q", got, want)
+	}
+}
+
+func TestWriteReadyMarker_Atomic(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".shaktiman", "ready")
+
+	if err := writeReadyMarker(path, "session-abc"); err != nil {
+		t.Fatalf("writeReadyMarker: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read marker: %v", err)
+	}
+	contents := string(data)
+	if !strings.Contains(contents, "session_id=session-abc") {
+		t.Errorf("marker missing session_id, got: %q", contents)
+	}
+	if !strings.Contains(contents, "pid=") {
+		t.Errorf("marker missing pid, got: %q", contents)
+	}
+	if !strings.Contains(contents, "started=") {
+		t.Errorf("marker missing started timestamp, got: %q", contents)
+	}
+
+	// No leftover .ready-* tempfile in the directory.
+	entries, err := os.ReadDir(filepath.Dir(path))
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), ".ready-") {
+			t.Fatalf("leftover tempfile: %s", e.Name())
+		}
+	}
+}
+
+func TestWriteReadyMarker_Overwrites(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".shaktiman", "ready")
+
+	if err := writeReadyMarker(path, "first"); err != nil {
+		t.Fatalf("first writeReadyMarker: %v", err)
+	}
+	if err := writeReadyMarker(path, "second"); err != nil {
+		t.Fatalf("second writeReadyMarker: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read marker: %v", err)
+	}
+	if !strings.Contains(string(data), "session_id=second") {
+		t.Errorf("marker not overwritten, got: %q", data)
+	}
+}

--- a/internal/proxy/bridge.go
+++ b/internal/proxy/bridge.go
@@ -5,9 +5,9 @@
 package proxy
 
 import (
-	"bufio"
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -15,16 +15,25 @@ import (
 	"net"
 	"net/http"
 	"syscall"
+	"time"
 )
 
 // ErrLeaderGone indicates the leader daemon has exited or is unreachable.
 var ErrLeaderGone = errors.New("leader daemon is no longer available")
 
-// maxMessageSize is the maximum JSON-RPC message size (1 MB).
-const maxMessageSize = 1 << 20
+// requestTimeout bounds a single MCP request round-trip. Generous enough
+// for slow tool calls (large search/context) yet short enough that a
+// genuinely wedged leader is detected instead of hanging the client
+// forever.
+const requestTimeout = 5 * time.Minute
+
+// responseHeaderTimeout bounds how long we wait for the leader to begin
+// responding. Catches a leader that accepted the connection but is stuck
+// before producing headers.
+const responseHeaderTimeout = 30 * time.Second
 
 // Bridge connects a Claude Code client (via Stdin/Stdout) to a leader daemon
-// (via Unix domain socket HTTP). It reads JSON-RPC lines from Stdin, POSTs
+// (via Unix domain socket HTTP). It reads JSON-RPC messages from Stdin, POSTs
 // them to the leader's /mcp endpoint, and writes responses to Stdout.
 type Bridge struct {
 	SocketPath string
@@ -42,66 +51,90 @@ func (b *Bridge) Run(ctx context.Context) error {
 			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
 				return (&net.Dialer{}).DialContext(ctx, "unix", b.SocketPath)
 			},
+			ResponseHeaderTimeout: responseHeaderTimeout,
 		},
 	}
 
-	scanner := bufio.NewScanner(b.Stdin)
-	scanner.Buffer(make([]byte, 0, maxMessageSize), maxMessageSize)
+	// json.Decoder handles arbitrary message size and whitespace framing
+	// without the 1 MiB cap that bufio.Scanner imposed (which silently
+	// killed the bridge on large tool-call payloads).
+	decoder := json.NewDecoder(b.Stdin)
 
 	var sessionID string
 
-	for scanner.Scan() {
-		line := scanner.Bytes()
-		if len(line) == 0 {
-			continue
+	for {
+		if ctx.Err() != nil {
+			return nil
 		}
 
-		req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://unix/mcp", bytes.NewReader(line))
-		if err != nil {
-			return fmt.Errorf("create request: %w", err)
-		}
-		req.Header.Set("Content-Type", "application/json")
-		if sessionID != "" {
-			req.Header.Set("Mcp-Session-Id", sessionID)
-		}
-
-		resp, err := client.Do(req)
-		if err != nil {
-			if isConnectionRefused(err) {
-				return ErrLeaderGone
+		var msg json.RawMessage
+		if err := decoder.Decode(&msg); err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
 			}
 			if ctx.Err() != nil {
-				return nil // context cancelled = clean shutdown
+				return nil
 			}
-			return fmt.Errorf("proxy request: %w", err)
+			return fmt.Errorf("stdin decode: %w", err)
 		}
 
-		// Capture session ID from the first response.
-		if sessionID == "" {
-			if id := resp.Header.Get("Mcp-Session-Id"); id != "" {
-				sessionID = id
-			}
-		}
-
-		body, err := io.ReadAll(resp.Body)
-		_ = resp.Body.Close()
+		body, newSessionID, err := b.forward(ctx, client, msg, sessionID)
 		if err != nil {
-			return fmt.Errorf("read response: %w", err)
+			if ctx.Err() != nil {
+				return nil
+			}
+			return err
+		}
+		if newSessionID != "" {
+			sessionID = newSessionID
 		}
 
-		// Write response followed by newline (JSON-RPC line framing).
 		body = bytes.TrimRight(body, "\r\n")
 		if _, err := fmt.Fprintf(b.Stdout, "%s\n", body); err != nil {
 			return fmt.Errorf("write stdout: %w", err)
 		}
 	}
+}
 
-	if err := scanner.Err(); err != nil {
-		return fmt.Errorf("stdin scan: %w", err)
+// forward sends one JSON-RPC message to the leader and returns the
+// response body plus any Mcp-Session-Id header value the server sent.
+// A per-request timeout bounds each round-trip independently of the
+// outer context.
+func (b *Bridge) forward(ctx context.Context, client *http.Client, msg json.RawMessage, sessionID string) ([]byte, string, error) {
+	reqCtx, cancel := context.WithTimeout(ctx, requestTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, "http://unix/mcp", bytes.NewReader(msg))
+	if err != nil {
+		return nil, "", fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if sessionID != "" {
+		req.Header.Set("Mcp-Session-Id", sessionID)
 	}
 
-	// Stdin closed (EOF) — clean exit.
-	return nil
+	resp, err := client.Do(req)
+	if err != nil {
+		if isConnectionRefused(err) {
+			return nil, "", ErrLeaderGone
+		}
+		if ctx.Err() != nil {
+			return nil, "", nil //nolint:nilnil // signaled via outer ctx; caller treats as clean shutdown
+		}
+		return nil, "", fmt.Errorf("proxy request: %w", err)
+	}
+
+	// Refresh on every response — the leader may rotate session IDs (e.g.
+	// after re-initialize) and the previous bridge only captured the
+	// first.
+	newSessionID := resp.Header.Get("Mcp-Session-Id")
+
+	body, err := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		return nil, "", fmt.Errorf("read response: %w", err)
+	}
+	return body, newSessionID, nil
 }
 
 // isConnectionRefused returns true if the error indicates the Unix socket

--- a/internal/proxy/bridge_test.go
+++ b/internal/proxy/bridge_test.go
@@ -296,6 +296,112 @@ func TestBridge_SessionHeader(t *testing.T) {
 	}
 }
 
+// TestBridge_SessionRefresh verifies that the bridge picks up a new
+// session ID from any response, not just the first. This matters when
+// the leader rotates session state mid-stream (e.g. re-initialize); the
+// previous bufio.Scanner-based bridge captured only the first ID and
+// kept sending it forever.
+func TestBridge_SessionRefresh(t *testing.T) {
+	t.Parallel()
+
+	sockPath := testSocketPath(t)
+
+	var mu sync.Mutex
+	var receivedSessionIDs []string
+	respIDs := []string{"sess-1", "sess-2", "sess-3"}
+	var respIdx int
+
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("net.Listen: %v", err)
+	}
+	defer ln.Close()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/mcp", func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		receivedSessionIDs = append(receivedSessionIDs, r.Header.Get("Mcp-Session-Id"))
+		id := respIDs[respIdx]
+		respIdx++
+		mu.Unlock()
+
+		body, _ := io.ReadAll(r.Body)
+		r.Body.Close()
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Mcp-Session-Id", id)
+		w.Write(body)
+	})
+
+	srv := &http.Server{Handler: mux}
+	go srv.Serve(ln)
+	defer srv.Close()
+
+	input := `{"jsonrpc":"2.0","id":1,"method":"a"}` + "\n" +
+		`{"jsonrpc":"2.0","id":2,"method":"b"}` + "\n" +
+		`{"jsonrpc":"2.0","id":3,"method":"c"}` + "\n"
+	stdin := strings.NewReader(input)
+	var stdout bytes.Buffer
+
+	b := &Bridge{
+		SocketPath: sockPath,
+		Stdin:      stdin,
+		Stdout:     &stdout,
+		Logger:     slog.Default(),
+	}
+
+	if err := b.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(receivedSessionIDs) != 3 {
+		t.Fatalf("expected 3 requests, got %d", len(receivedSessionIDs))
+	}
+	if receivedSessionIDs[0] != "" {
+		t.Fatalf("first request: want empty session ID, got %q", receivedSessionIDs[0])
+	}
+	if receivedSessionIDs[1] != "sess-1" {
+		t.Fatalf("second request: want sess-1, got %q", receivedSessionIDs[1])
+	}
+	// Critical: third request must use sess-2 (refreshed), not sess-1.
+	if receivedSessionIDs[2] != "sess-2" {
+		t.Fatalf("third request: want sess-2 (refreshed), got %q", receivedSessionIDs[2])
+	}
+}
+
+// TestBridge_OversizedPayload sends a 2 MiB payload (above the old 1 MiB
+// bufio.Scanner cap) to confirm json.Decoder framing handles it.
+func TestBridge_OversizedPayload(t *testing.T) {
+	t.Parallel()
+
+	sockPath := testSocketPath(t)
+	ln, srv := startTestHTTPServer(t, sockPath)
+	defer ln.Close()
+	defer srv.Close()
+
+	large := `{"jsonrpc":"2.0","id":1,"method":"test","params":{"data":"` +
+		strings.Repeat("x", 2*1024*1024) +
+		`"}}` + "\n"
+	stdin := strings.NewReader(large)
+	var stdout bytes.Buffer
+
+	b := &Bridge{
+		SocketPath: sockPath,
+		Stdin:      stdin,
+		Stdout:     &stdout,
+		Logger:     slog.Default(),
+	}
+
+	if err := b.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if stdout.Len() < 2*1024*1024 {
+		t.Fatalf("response too short (%d bytes)", stdout.Len())
+	}
+}
+
 func TestBridge_LeaderExitsMidStream(t *testing.T) {
 	t.Parallel()
 
@@ -435,8 +541,8 @@ func TestBridge_ScannerError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error from scanner")
 	}
-	if !strings.Contains(err.Error(), "stdin scan") {
-		t.Fatalf("expected stdin scan error, got: %v", err)
+	if !strings.Contains(err.Error(), "stdin decode") {
+		t.Fatalf("expected stdin decode error, got: %v", err)
 	}
 }
 

--- a/internal/proxy/wait.go
+++ b/internal/proxy/wait.go
@@ -3,21 +3,25 @@ package proxy
 import (
 	"fmt"
 	"net"
+	"os"
 	"time"
 )
+
+// waitBackoffs is the shared exponential progression used by both
+// WaitForSocket and WaitForReady to space their poll attempts.
+var waitBackoffs = []time.Duration{
+	100 * time.Millisecond,
+	200 * time.Millisecond,
+	500 * time.Millisecond,
+	1 * time.Second,
+	2 * time.Second,
+}
 
 // WaitForSocket waits for a Unix domain socket to become connectable,
 // using exponential backoff. Returns nil when the socket accepts a connection,
 // or an error if the timeout is reached.
 func WaitForSocket(path string, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
-	backoffs := []time.Duration{
-		100 * time.Millisecond,
-		200 * time.Millisecond,
-		500 * time.Millisecond,
-		1 * time.Second,
-		2 * time.Second,
-	}
 	for i := 0; ; i++ {
 		conn, err := net.DialTimeout("unix", path, 500*time.Millisecond)
 		if err == nil {
@@ -27,10 +31,38 @@ func WaitForSocket(path string, timeout time.Duration) error {
 		if time.Now().After(deadline) {
 			return fmt.Errorf("socket %s not available after %v", path, timeout)
 		}
-		idx := i
-		if idx >= len(backoffs) {
-			idx = len(backoffs) - 1
-		}
-		time.Sleep(backoffs[idx])
+		time.Sleep(backoffAt(i))
 	}
+}
+
+// WaitForReady waits until both (a) the leader has written its readiness
+// marker file and (b) its Unix socket is dialable. The marker is the
+// authoritative signal that the leader's MCP HTTP server is wired up
+// and serving — a bare socket connect can otherwise succeed against the
+// kernel listen backlog before Serve is actually accepting.
+//
+// Returns nil on success, or a descriptive error after the timeout.
+func WaitForReady(socketPath, markerPath string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for i := 0; ; i++ {
+		if _, err := os.Stat(markerPath); err == nil {
+			conn, dialErr := net.DialTimeout("unix", socketPath, 500*time.Millisecond)
+			if dialErr == nil {
+				_ = conn.Close()
+				return nil
+			}
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("leader not ready after %v (marker=%s socket=%s)",
+				timeout, markerPath, socketPath)
+		}
+		time.Sleep(backoffAt(i))
+	}
+}
+
+func backoffAt(i int) time.Duration {
+	if i >= len(waitBackoffs) {
+		return waitBackoffs[len(waitBackoffs)-1]
+	}
+	return waitBackoffs[i]
 }

--- a/internal/proxy/wait_test.go
+++ b/internal/proxy/wait_test.go
@@ -2,6 +2,8 @@ package proxy
 
 import (
 	"net"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -64,5 +66,90 @@ func TestWaitForSocket_BackoffProgression(t *testing.T) {
 	}
 	if elapsed > 1*time.Second {
 		t.Fatalf("took too long: %v", elapsed)
+	}
+}
+
+// TestWaitForReady_RequiresMarker verifies that WaitForReady will not
+// return success while the readiness marker is absent, even if the
+// socket itself is dialable. This is the core invariant: a bare
+// listener is not a ready leader.
+func TestWaitForReady_RequiresMarker(t *testing.T) {
+	t.Parallel()
+
+	sockPath := testSocketPath(t)
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("net.Listen: %v", err)
+	}
+	defer ln.Close()
+
+	markerPath := filepath.Join(t.TempDir(), "ready")
+	// Marker missing → must time out despite socket being dialable.
+	if err := WaitForReady(sockPath, markerPath, 250*time.Millisecond); err == nil {
+		t.Fatal("expected timeout when marker absent")
+	}
+}
+
+// TestWaitForReady_Success verifies the happy path: marker present and
+// socket dialable.
+func TestWaitForReady_Success(t *testing.T) {
+	t.Parallel()
+
+	sockPath := testSocketPath(t)
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("net.Listen: %v", err)
+	}
+	defer ln.Close()
+
+	markerPath := filepath.Join(t.TempDir(), "ready")
+	if err := os.WriteFile(markerPath, []byte("ok"), 0o600); err != nil {
+		t.Fatalf("write marker: %v", err)
+	}
+
+	if err := WaitForReady(sockPath, markerPath, 2*time.Second); err != nil {
+		t.Fatalf("expected success, got: %v", err)
+	}
+}
+
+// TestWaitForReady_EventualMarker verifies that WaitForReady polls and
+// eventually succeeds once the marker shows up. Models the realistic
+// startup path where the proxy connects before the leader's HTTP
+// server has finished wiring up.
+func TestWaitForReady_EventualMarker(t *testing.T) {
+	t.Parallel()
+
+	sockPath := testSocketPath(t)
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("net.Listen: %v", err)
+	}
+	defer ln.Close()
+
+	markerPath := filepath.Join(t.TempDir(), "ready")
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		_ = os.WriteFile(markerPath, []byte("ok"), 0o600)
+	}()
+
+	if err := WaitForReady(sockPath, markerPath, 3*time.Second); err != nil {
+		t.Fatalf("expected eventual success, got: %v", err)
+	}
+}
+
+// TestWaitForReady_SocketUnreachable verifies that a stale marker (left
+// behind after a crash) does not falsely report ready when the socket
+// is unreachable.
+func TestWaitForReady_SocketUnreachable(t *testing.T) {
+	t.Parallel()
+
+	sockPath := testSocketPath(t) // helper removes the file
+	markerPath := filepath.Join(t.TempDir(), "ready")
+	if err := os.WriteFile(markerPath, []byte("stale"), 0o600); err != nil {
+		t.Fatalf("write marker: %v", err)
+	}
+
+	if err := WaitForReady(sockPath, markerPath, 250*time.Millisecond); err == nil {
+		t.Fatal("expected timeout when socket unreachable")
 	}
 }


### PR DESCRIPTION
  - PR 3.1 (9940ce4): Re-exec uses os.Executable() instead of os.Args[0]; adds 50–500ms jittered backoff before
  promotion; raises promotionWaitTimeout from 5s to 30s.
  - PR 3.2 (57dbc40): Replaces bufio.Scanner (1 MiB cap) with json.Decoder; adds 5m per-request timeout + 30s
  ResponseHeaderTimeout; refreshes Mcp-Session-Id on every response, not just the first.
  - PR 3.3 (8769a00): Leader writes .shaktiman/ready (atomic temp+rename) just before Serve and removes it on graceful
   Stop; proxy.WaitForReady polls both marker and socket; socket-shutdown deadline raised from 2s to 15s so in-flight
  tools/call drains.