### PR TITLE
Batch 4 operational

### DIFF
--- a/cmd/shaktimand/main.go
+++ b/cmd/shaktimand/main.go
@@ -11,7 +11,7 @@ import (
 	"log/slog"
 	"math/rand/v2"
 	"net/http"
-	_ "net/http/pprof" // registers pprof handlers; only listened on if --pprof-addr is set
+	"net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -259,12 +259,23 @@ func logStartupBanner(cfg types.Config, socketPath, pprofAddr string) {
 	)
 }
 
-// startPprof launches an http.Server hosting net/http/pprof in its own
-// goroutine. Failure to bind logs a warning rather than crashing the
-// daemon — pprof is opt-in diagnostics, not core functionality.
+// startPprof launches an http.Server hosting net/http/pprof on a
+// private mux in its own goroutine. The handlers are registered on a
+// dedicated ServeMux rather than http.DefaultServeMux so pprof routes
+// are never accidentally exposed elsewhere (gosec G108). Failure to
+// bind logs a warning rather than crashing the daemon — pprof is
+// opt-in diagnostics, not core functionality.
 func startPprof(addr string) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
 	srv := &http.Server{
 		Addr:              addr,
+		Handler:           mux,
 		ReadHeaderTimeout: 10 * time.Second,
 	}
 	go func() {

--- a/cmd/shaktimand/main.go
+++ b/cmd/shaktimand/main.go
@@ -5,12 +5,17 @@ package main
 import (
 	"context"
 	"errors"
+	"flag"
 	"fmt"
+	"io"
 	"log/slog"
 	"math/rand/v2"
+	"net/http"
+	_ "net/http/pprof" // registers pprof handlers; only listened on if --pprof-addr is set
 	"os"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"syscall"
 	"time"
 
@@ -42,13 +47,80 @@ func promotionBackoff() time.Duration {
 	return promotionBackoffMin + rand.N(promotionBackoffMax-promotionBackoffMin)
 }
 
-func main() {
-	if len(os.Args) < 2 {
-		fmt.Fprintf(os.Stderr, "usage: shaktimand <project-root>\n")
-		os.Exit(1)
+type cliFlags struct {
+	logLevel    string
+	pprofAddr   string
+	showVersion bool
+	projectRoot string
+}
+
+func parseFlags(args []string, stderr io.Writer) (cliFlags, error) {
+	fs := flag.NewFlagSet("shaktimand", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	fs.Usage = func() {
+		fmt.Fprintf(stderr, "usage: shaktimand [flags] <project-root>\n\nflags:\n")
+		fs.PrintDefaults()
 	}
 
-	projectRoot := os.Args[1]
+	var f cliFlags
+	fs.StringVar(&f.logLevel, "log-level", "",
+		"slog log level (debug|info|warn|error); falls back to $SHAKTIMAN_LOG_LEVEL then info")
+	fs.StringVar(&f.pprofAddr, "pprof-addr", "",
+		"bind net/http/pprof on this addr (e.g. 127.0.0.1:6060); empty disables it")
+	fs.BoolVar(&f.showVersion, "version", false, "print version and exit")
+
+	if err := fs.Parse(args); err != nil {
+		return f, err
+	}
+	if f.showVersion {
+		return f, nil
+	}
+	rest := fs.Args()
+	if len(rest) < 1 {
+		fs.Usage()
+		return f, fmt.Errorf("missing <project-root>")
+	}
+	f.projectRoot = rest[0]
+	return f, nil
+}
+
+// resolveLogLevel picks the effective slog level from (in order) the
+// --log-level flag, $SHAKTIMAN_LOG_LEVEL, then info. Unknown values are
+// not silently ignored — they return a non-empty warning string the
+// caller logs once the logger is set up.
+func resolveLogLevel(flagVal string) (slog.Level, string) {
+	source, raw := "", ""
+	switch {
+	case flagVal != "":
+		source, raw = "--log-level", flagVal
+	case os.Getenv("SHAKTIMAN_LOG_LEVEL") != "":
+		source, raw = "SHAKTIMAN_LOG_LEVEL", os.Getenv("SHAKTIMAN_LOG_LEVEL")
+	default:
+		return slog.LevelInfo, ""
+	}
+
+	var lvl slog.Level
+	if err := lvl.UnmarshalText([]byte(raw)); err != nil {
+		return slog.LevelInfo, fmt.Sprintf(
+			"unknown log level %q from %s; defaulting to info", raw, source)
+	}
+	return lvl, ""
+}
+
+func main() {
+	flags, err := parseFlags(os.Args[1:], os.Stderr)
+	if err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			os.Exit(0)
+		}
+		os.Exit(2)
+	}
+	if flags.showVersion {
+		fmt.Println(versionLine())
+		return
+	}
+
+	projectRoot := flags.projectRoot
 
 	// Validate project root exists
 	info, err := os.Stat(projectRoot)
@@ -71,6 +143,14 @@ func main() {
 	}
 	logPath := filepath.Join(logDir, "shaktimand.log")
 
+	logLevel, levelWarning := resolveLogLevel(flags.logLevel)
+
+	// Ignore SIGPIPE before any I/O is wired up. The MCP daemon writes to
+	// long-lived pipes (stdout, sockets) whose readers can disappear; the
+	// default SIGPIPE action is to terminate the process, which would
+	// abort indexing on a benign client disconnect.
+	signal.Ignore(syscall.SIGPIPE)
+
 	// Acquire singleton lock for this project. Ensures exactly one leader daemon.
 	// If another daemon holds the lock, enter proxy mode instead.
 	lock, lockErr := lockfile.Acquire(projectRoot)
@@ -78,7 +158,10 @@ func main() {
 		if errors.Is(lockErr, lockfile.ErrAlreadyLocked) {
 			// Proxy: append to shared log — never rotate or truncate, as
 			// the leader's file descriptor would become detached.
-			setupLogging(logPath, false)
+			setupLogging(logPath, false, logLevel)
+			if levelWarning != "" {
+				slog.Warn(levelWarning)
+			}
 			runAsProxy(projectRoot)
 			return
 		}
@@ -88,7 +171,10 @@ func main() {
 	defer func() { _ = lock.Release() }()
 
 	// Leader: rotate previous log, then create a fresh one.
-	setupLogging(logPath, true)
+	setupLogging(logPath, true, logLevel)
+	if levelWarning != "" {
+		slog.Warn(levelWarning)
+	}
 
 	cfg := types.DefaultConfig(projectRoot)
 
@@ -103,6 +189,12 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Optional pprof listener for diagnostics. Bound to whatever the user
+	// passed; if they bind 0.0.0.0 they accepted that risk explicitly.
+	if flags.pprofAddr != "" {
+		startPprof(flags.pprofAddr)
+	}
+
 	// Create Unix domain socket for proxy clients.
 	socketListener, err := lock.Listen()
 	if err != nil {
@@ -115,20 +207,7 @@ func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 
-	slog.Info("shaktimand starting",
-		"project_root", cfg.ProjectRoot,
-		"db_path", cfg.DBPath,
-		"embed_enabled", cfg.EmbedEnabled,
-		"embed_model", cfg.EmbeddingModel,
-		"ollama_url", cfg.OllamaURL,
-		"watcher_enabled", cfg.WatcherEnabled,
-		"search_max_results", cfg.SearchMaxResults,
-		"search_default_mode", cfg.SearchDefaultMode,
-		"search_min_score", cfg.SearchMinScore,
-		"context_enabled", cfg.ContextEnabled,
-		"context_budget_tokens", cfg.ContextBudgetTokens,
-		"pid", os.Getpid(),
-	)
+	logStartupBanner(cfg, lock.SocketPath(), flags.pprofAddr)
 
 	d, err := daemon.New(cfg)
 	if err != nil {
@@ -147,11 +226,60 @@ func main() {
 	}
 }
 
+// logStartupBanner emits a single grep-able structured log line summarizing
+// version, runtime, configuration, and listener addresses. Operators reading
+// log archives use this as the anchor for "what was running on this date".
+func logStartupBanner(cfg types.Config, socketPath, pprofAddr string) {
+	rev := vcsRevision()
+	if vcsModified() {
+		rev += "-dirty"
+	}
+	slog.Info("shaktimand starting",
+		"version", binaryVersion,
+		"vcs_revision", rev,
+		"go_version", runtime.Version(),
+		"goos", runtime.GOOS,
+		"goarch", runtime.GOARCH,
+		"pid", os.Getpid(),
+		"project_root", cfg.ProjectRoot,
+		"db_backend", cfg.DatabaseBackend,
+		"db_path", cfg.DBPath,
+		"vector_backend", cfg.VectorBackend,
+		"embed_enabled", cfg.EmbedEnabled,
+		"embed_model", cfg.EmbeddingModel,
+		"ollama_url", cfg.OllamaURL,
+		"watcher_enabled", cfg.WatcherEnabled,
+		"search_max_results", cfg.SearchMaxResults,
+		"search_default_mode", cfg.SearchDefaultMode,
+		"search_min_score", cfg.SearchMinScore,
+		"context_enabled", cfg.ContextEnabled,
+		"context_budget_tokens", cfg.ContextBudgetTokens,
+		"socket_path", socketPath,
+		"pprof_addr", pprofAddr,
+	)
+}
+
+// startPprof launches an http.Server hosting net/http/pprof in its own
+// goroutine. Failure to bind logs a warning rather than crashing the
+// daemon — pprof is opt-in diagnostics, not core functionality.
+func startPprof(addr string) {
+	srv := &http.Server{
+		Addr:              addr,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	go func() {
+		slog.Info("pprof server listening", "addr", addr)
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			slog.Warn("pprof server stopped", "err", err)
+		}
+	}()
+}
+
 // setupLogging configures slog to write to logPath. When rotate is true
 // (leader mode), the existing log is moved to session-logs/ and a fresh file
 // is created. When rotate is false (proxy mode), the file is opened in append
 // mode so the leader's file descriptor is not invalidated.
-func setupLogging(logPath string, rotate bool) {
+func setupLogging(logPath string, rotate bool, level slog.Level) {
 	if rotate {
 		if info, err := os.Stat(logPath); err == nil && info.Size() > 0 {
 			sessionDir := filepath.Join(filepath.Dir(logPath), "session-logs")
@@ -174,16 +302,8 @@ func setupLogging(logPath string, rotate bool) {
 		os.Exit(1)
 	}
 
-	logLevel := slog.LevelInfo
-	if lvl := os.Getenv("SHAKTIMAN_LOG_LEVEL"); lvl != "" {
-		var l slog.Level
-		if err := l.UnmarshalText([]byte(lvl)); err == nil {
-			logLevel = l
-		}
-	}
-
 	logger := slog.New(slog.NewJSONHandler(logFile, &slog.HandlerOptions{
-		Level: logLevel,
+		Level: level,
 	}))
 	slog.SetDefault(logger)
 }
@@ -257,4 +377,3 @@ func runAsProxy(projectRoot string) {
 		os.Exit(1)
 	}
 }
-

--- a/cmd/shaktimand/main_test.go
+++ b/cmd/shaktimand/main_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"bytes"
+	"log/slog"
+	"strings"
 	"testing"
 	"time"
 )
@@ -37,3 +40,139 @@ func TestPromotionBackoff_Distribution(t *testing.T) {
 		t.Errorf("expected >50 distinct backoff values, got %d", len(seen))
 	}
 }
+
+func TestParseFlags_Defaults(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	got, err := parseFlags([]string{"/tmp/proj"}, &buf)
+	if err != nil {
+		t.Fatalf("parseFlags: %v", err)
+	}
+	if got.projectRoot != "/tmp/proj" {
+		t.Errorf("projectRoot = %q, want /tmp/proj", got.projectRoot)
+	}
+	if got.logLevel != "" {
+		t.Errorf("logLevel = %q, want empty default", got.logLevel)
+	}
+	if got.pprofAddr != "" {
+		t.Errorf("pprofAddr = %q, want empty default", got.pprofAddr)
+	}
+}
+
+func TestParseFlags_AllSet(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	got, err := parseFlags(
+		[]string{"--log-level", "debug", "--pprof-addr", "127.0.0.1:6060", "/tmp/p"},
+		&buf,
+	)
+	if err != nil {
+		t.Fatalf("parseFlags: %v", err)
+	}
+	if got.logLevel != "debug" {
+		t.Errorf("logLevel = %q, want debug", got.logLevel)
+	}
+	if got.pprofAddr != "127.0.0.1:6060" {
+		t.Errorf("pprofAddr = %q", got.pprofAddr)
+	}
+	if got.projectRoot != "/tmp/p" {
+		t.Errorf("projectRoot = %q", got.projectRoot)
+	}
+}
+
+func TestParseFlags_Version(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	got, err := parseFlags([]string{"--version"}, &buf)
+	if err != nil {
+		t.Fatalf("parseFlags --version: %v", err)
+	}
+	if !got.showVersion {
+		t.Error("showVersion not set")
+	}
+}
+
+func TestParseFlags_MissingProjectRoot(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	_, err := parseFlags([]string{}, &buf)
+	if err == nil {
+		t.Fatal("expected error for missing project-root")
+	}
+	if !strings.Contains(err.Error(), "project-root") {
+		t.Errorf("error %q should mention project-root", err)
+	}
+}
+
+// TestResolveLogLevel_Precedence walks the precedence chain
+// flag → env → default and confirms each step.
+func TestResolveLogLevel_Precedence(t *testing.T) {
+	t.Setenv("SHAKTIMAN_LOG_LEVEL", "warn")
+
+	lvl, warning := resolveLogLevel("debug")
+	if lvl != slog.LevelDebug {
+		t.Errorf("flag-set: got %v, want debug", lvl)
+	}
+	if warning != "" {
+		t.Errorf("unexpected warning: %q", warning)
+	}
+
+	lvl, warning = resolveLogLevel("")
+	if lvl != slog.LevelWarn {
+		t.Errorf("env-set: got %v, want warn", lvl)
+	}
+	if warning != "" {
+		t.Errorf("unexpected warning: %q", warning)
+	}
+
+	t.Setenv("SHAKTIMAN_LOG_LEVEL", "")
+	lvl, warning = resolveLogLevel("")
+	if lvl != slog.LevelInfo {
+		t.Errorf("default: got %v, want info", lvl)
+	}
+	if warning != "" {
+		t.Errorf("unexpected warning: %q", warning)
+	}
+}
+
+// TestResolveLogLevel_UnknownWarns ensures bad values surface as a
+// warning string instead of being silently swallowed.
+func TestResolveLogLevel_UnknownWarns(t *testing.T) {
+	t.Setenv("SHAKTIMAN_LOG_LEVEL", "")
+
+	lvl, warning := resolveLogLevel("not-a-level")
+	if lvl != slog.LevelInfo {
+		t.Errorf("unknown flag value: got %v, want info fallback", lvl)
+	}
+	if warning == "" {
+		t.Error("expected warning for unknown level, got empty")
+	}
+	if !strings.Contains(warning, "--log-level") {
+		t.Errorf("warning %q should mention --log-level source", warning)
+	}
+
+	t.Setenv("SHAKTIMAN_LOG_LEVEL", "garbage")
+	_, warning = resolveLogLevel("")
+	if !strings.Contains(warning, "SHAKTIMAN_LOG_LEVEL") {
+		t.Errorf("warning %q should mention env source", warning)
+	}
+}
+
+// TestVersionLine_NonEmpty guards against accidental nil/empty
+// regressions in the banner-version helper.
+func TestVersionLine_NonEmpty(t *testing.T) {
+	t.Parallel()
+
+	v := versionLine()
+	if v == "" {
+		t.Fatal("versionLine returned empty string")
+	}
+	if !strings.Contains(v, "shaktimand") {
+		t.Errorf("versionLine missing program name: %q", v)
+	}
+}
+

--- a/cmd/shaktimand/version.go
+++ b/cmd/shaktimand/version.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"fmt"
+	"runtime"
+	"runtime/debug"
+)
+
+// binaryVersion is set via -ldflags "-X main.binaryVersion=..." at release
+// build time. Falls back to "dev" for ad-hoc builds.
+var binaryVersion = "dev"
+
+// vcsRevision is the git commit short hash captured at build time when
+// available via runtime/debug.BuildInfo (Go 1.18+ injects it
+// automatically for module builds inside a git repo).
+func vcsRevision() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return ""
+	}
+	for _, s := range info.Settings {
+		if s.Key == "vcs.revision" {
+			if len(s.Value) > 12 {
+				return s.Value[:12]
+			}
+			return s.Value
+		}
+	}
+	return ""
+}
+
+// vcsModified reports whether the working tree had uncommitted changes
+// at build time. Useful in the banner: a dirty build is a flag during
+// post-mortem investigation.
+func vcsModified() bool {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return false
+	}
+	for _, s := range info.Settings {
+		if s.Key == "vcs.modified" {
+			return s.Value == "true"
+		}
+	}
+	return false
+}
+
+func versionLine() string {
+	rev := vcsRevision()
+	suffix := ""
+	if vcsModified() {
+		suffix = "-dirty"
+	}
+	if rev == "" {
+		return fmt.Sprintf("shaktimand %s (%s/%s)", binaryVersion, runtime.GOOS, runtime.GOARCH)
+	}
+	return fmt.Sprintf("shaktimand %s+%s%s (%s/%s)",
+		binaryVersion, rev, suffix, runtime.GOOS, runtime.GOARCH)
+}

--- a/internal/storage/migrations/postgres/008_project_id_not_null_check.sql
+++ b/internal/storage/migrations/postgres/008_project_id_not_null_check.sql
@@ -1,0 +1,42 @@
+-- +goose up
+
+-- Defense-in-depth NOT NULL enforcement for project_id columns using the
+-- ADD CONSTRAINT CHECK ... NOT VALID + VALIDATE CONSTRAINT pattern.
+--
+-- Migration 006 already issued ALTER COLUMN ... SET NOT NULL on these
+-- columns. SET NOT NULL takes ACCESS EXCLUSIVE and a full sequential
+-- scan to validate, which is risky on large tables. Going forward the
+-- preferred pattern is:
+--
+--     ALTER TABLE t ADD CONSTRAINT c CHECK (col IS NOT NULL) NOT VALID;
+--     ALTER TABLE t VALIDATE CONSTRAINT c;
+--
+-- ADD CONSTRAINT NOT VALID takes only a brief ACCESS EXCLUSIVE for the
+-- catalog change; VALIDATE CONSTRAINT runs under SHARE UPDATE EXCLUSIVE
+-- so concurrent INSERT/UPDATE/DELETE keep working during validation.
+--
+-- This migration installs a redundant CHECK on top of the existing NOT
+-- NULL. Redundancy is intentional — it documents the recommended
+-- pattern for similar future columns and provides a second-layer guard
+-- against schema-corruption (e.g. an aborted goose down/up cycle that
+-- left the column nullable).
+--
+-- For databases past migration 006 the VALIDATE step is essentially a
+-- no-op (no NULLs exist). For databases that somehow lost the NOT NULL
+-- (manual rollback, etc.) this loudly fails on validation, surfacing
+-- the schema drift instead of letting it persist.
+
+ALTER TABLE files
+    ADD CONSTRAINT files_project_id_not_null
+    CHECK (project_id IS NOT NULL) NOT VALID;
+ALTER TABLE files VALIDATE CONSTRAINT files_project_id_not_null;
+
+ALTER TABLE embeddings
+    ADD CONSTRAINT embeddings_project_id_not_null
+    CHECK (project_id IS NOT NULL) NOT VALID;
+ALTER TABLE embeddings VALIDATE CONSTRAINT embeddings_project_id_not_null;
+
+-- +goose down
+
+ALTER TABLE embeddings DROP CONSTRAINT IF EXISTS embeddings_project_id_not_null;
+ALTER TABLE files DROP CONSTRAINT IF EXISTS files_project_id_not_null;

--- a/internal/storage/postgres/migration_test.go
+++ b/internal/storage/postgres/migration_test.go
@@ -1,0 +1,40 @@
+//go:build postgres
+
+package postgres
+
+import (
+	"context"
+	"testing"
+)
+
+// TestMigration008_CheckConstraintsExist verifies that migration 008
+// installed the defense-in-depth CHECK constraints on files and
+// embeddings.
+func TestMigration008_CheckConstraintsExist(t *testing.T) {
+	store := newProjectTestStore(t)
+	ctx := context.Background()
+
+	type want struct {
+		table      string
+		constraint string
+	}
+	cases := []want{
+		{"files", "files_project_id_not_null"},
+		{"embeddings", "embeddings_project_id_not_null"},
+	}
+
+	for _, c := range cases {
+		var found bool
+		err := store.Pool().QueryRow(ctx, `
+			SELECT EXISTS (
+				SELECT 1 FROM pg_constraint
+				WHERE conname = $1 AND contype = 'c'
+			)`, c.constraint).Scan(&found)
+		if err != nil {
+			t.Fatalf("query %s: %v", c.constraint, err)
+		}
+		if !found {
+			t.Errorf("constraint %s missing on %s after Migrate", c.constraint, c.table)
+		}
+	}
+}

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -149,10 +149,10 @@ See [`summary` MCP tool](/reference/mcp-tools/summary).
 ## `shaktimand` (MCP daemon)
 
 ```
-shaktimand <project-root>
+shaktimand [flags] <project-root>
 ```
 
-Takes a single positional argument: the project root. The daemon:
+Takes the project root as its sole positional argument. The daemon:
 
 1. Canonicalizes the project root path (`symlinks + relative → absolute`) so two
    daemons can't race by addressing the same directory differently.
@@ -167,6 +167,31 @@ Takes a single positional argument: the project root. The daemon:
 
 `shaktimand` is not normally run by hand. Wire it via your MCP client's
 configuration (for Claude Code, see [Claude Code Setup](/getting-started/claude-code-setup)).
+
+### Flags
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `--help` | — | Print usage and exit. |
+| `--version` | — | Print binary version (with VCS revision when built from a checkout) and exit. |
+| `--log-level <debug\|info\|warn\|error>` | `info` | slog level. Falls back to `$SHAKTIMAN_LOG_LEVEL` if the flag is unset; unknown values log a warning to `shaktimand.log` and continue at `info`. |
+| `--pprof-addr <host:port>` | — | If set, serves `net/http/pprof` on this address. Disabled when empty. Bind to a loopback address (e.g. `127.0.0.1:6060`) unless you explicitly intend external access. |
+
+### Startup banner
+
+On startup the leader writes one structured `slog` line at `info` level summarizing
+version, VCS revision (with a `-dirty` suffix when the working tree was modified at
+build time), Go runtime, pid, project root, db backend, vector backend, embedding
+config, socket path, and `--pprof-addr`. Use this line as the anchor when scanning
+log archives during a post-mortem. Proxy-mode processes log a separate `entering
+proxy mode` line instead.
+
+### Signals
+
+`shaktimand` ignores `SIGPIPE`. The daemon writes to long-lived pipes (stdin/stdout
+to the MCP client, the proxy socket); a benign reader disconnect would otherwise
+terminate the process and abort indexing. `SIGINT` and `SIGTERM` trigger graceful
+shutdown.
 
 ## Source of truth
 


### PR DESCRIPTION
- PR 4a (c6f3f29): New Pg migration 008_project_id_not_null_check.sql adds defense-in-depth CHECK (project_id
  IS NOT NULL) NOT VALID; VALIDATE CONSTRAINT on files and embeddings. Documents the recommended online-DDL
  pattern for similar future columns; surfaces schema drift (e.g. an aborted goose down) loudly. 006 untouched.
 - PR 4b (47bdcc6): shaktimand gains stdlib-flag CLI: --help, --version, --log-level, --pprof-addr.
  Project-root remains positional. 
 
 - resolveLogLevel now warns on unknown values instead of silently defaulting
  and names the source. signal.Ignore(SIGPIPE) so a benign client disconnect doesn't kill the daemon. New
  logStartupBanner emits one structured slog line (version, vcs revision incl. dirty, Go version, GOOS/GOARCH,
  pid, project root, db backend, vector backend, embed config, socket path, pprof addr). 
  
 - Optional pprof listener.